### PR TITLE
Add theme toggle with persistent dark mode

### DIFF
--- a/static/css/theme-toggle.css
+++ b/static/css/theme-toggle.css
@@ -1,18 +1,29 @@
 :root {
   color-scheme: light dark;
+  --atlas-dark-body: #0f172a;
+  --atlas-dark-surface: #111c36;
+  --atlas-dark-surface-soft: #15254a;
+  --atlas-dark-border: rgba(148, 163, 184, 0.25);
+  --atlas-dark-text: #e2e8f0;
+  --atlas-dark-accent: #38bdf8;
+  --atlas-dark-accent-soft: rgba(56, 189, 248, 0.16);
+  --atlas-toggle-track-light: rgba(15, 23, 42, 0.08);
+  --atlas-toggle-track-dark: rgba(148, 163, 184, 0.2);
+  --atlas-toggle-thumb-light: linear-gradient(135deg, #fde68a, #f59e0b);
+  --atlas-toggle-thumb-dark: linear-gradient(135deg, #38bdf8, #6366f1);
 }
 
 body {
-  transition: background-color 0.4s ease, color 0.4s ease;
+  transition: background-color 0.45s ease, color 0.45s ease;
 }
 
 body.dark-theme {
-  background-color: #0f172a;
-  color: #e2e8f0;
+  background-color: var(--atlas-dark-body);
+  color: var(--atlas-dark-text);
 }
 
 body.dark-theme a {
-  color: #38bdf8;
+  color: var(--atlas-dark-accent);
 }
 
 body.dark-theme a:hover,
@@ -26,7 +37,7 @@ body.dark-theme .main-header,
 body.dark-theme .sticky-header,
 body.dark-theme .header-lower,
 body.dark-theme .page-wrapper {
-  background-color: #0b1120;
+  background: var(--atlas-dark-surface);
 }
 
 body.dark-theme .top-left .social-box a span,
@@ -36,19 +47,20 @@ body.dark-theme .dropdown-menu,
 body.dark-theme .dropdown-item,
 body.dark-theme .dropdown-item:focus,
 body.dark-theme .dropdown-item:hover {
-  color: #e2e8f0 !important;
+  color: var(--atlas-dark-text) !important;
 }
 
 body.dark-theme .dropdown-menu {
-  background-color: #111827;
-  border-color: rgba(148, 163, 184, 0.2);
+  background-color: rgba(15, 23, 42, 0.92);
+  border-color: var(--atlas-dark-border);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
 }
 
 body.dark-theme .dropdown-item:hover,
 body.dark-theme .dropdown-item:focus,
 body.dark-theme .dropdown-item.active {
-  background-color: rgba(59, 130, 246, 0.2);
-  color: #38bdf8 !important;
+  background-color: var(--atlas-dark-accent-soft);
+  color: var(--atlas-dark-accent) !important;
 }
 
 body.dark-theme .theme-btn,
@@ -56,9 +68,10 @@ body.dark-theme .btn,
 body.dark-theme .btn-box a,
 body.dark-theme .choose-btn,
 body.dark-theme .btn-style-two {
-  background: linear-gradient(120deg, #22d3ee, #6366f1);
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
   color: #0f172a !important;
   border: none;
+  box-shadow: 0 16px 40px rgba(99, 102, 241, 0.4);
 }
 
 body.dark-theme .theme-btn:hover,
@@ -66,8 +79,9 @@ body.dark-theme .btn:hover,
 body.dark-theme .btn-box a:hover,
 body.dark-theme .choose-btn:hover,
 body.dark-theme .btn-style-two:hover {
-  background: linear-gradient(120deg, #f97316, #facc15);
+  background: linear-gradient(135deg, #f97316, #facc15);
   color: #111827 !important;
+  box-shadow: 0 18px 46px rgba(249, 200, 39, 0.35);
 }
 
 body.dark-theme .price-block,
@@ -83,16 +97,16 @@ body.dark-theme .auto-container,
 body.dark-theme section,
 body.dark-theme .modal-content,
 body.dark-theme .my-modal-content {
-  background-color: rgba(15, 23, 42, 0.85);
-  color: #e2e8f0;
-  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.45);
-  border-color: rgba(148, 163, 184, 0.2);
+  background-color: rgba(17, 30, 56, 0.86);
+  color: var(--atlas-dark-text);
+  box-shadow: 0 20px 50px rgba(2, 6, 23, 0.55);
+  border-color: var(--atlas-dark-border);
 }
 
 body.dark-theme .testimonial-block.blue,
 body.dark-theme .price-block.style-two,
 body.dark-theme .testimonial-block.blue .inner-box {
-  background: linear-gradient(135deg, rgba(14, 116, 144, 0.8), rgba(67, 56, 202, 0.8));
+  background: linear-gradient(145deg, rgba(14, 116, 144, 0.82), rgba(67, 56, 202, 0.82));
 }
 
 body.dark-theme .main-footer,
@@ -103,7 +117,7 @@ body.dark-theme footer.main-footer {
 
 body.dark-theme .main-footer a,
 body.dark-theme footer.main-footer a {
-  color: #38bdf8;
+  color: var(--atlas-dark-accent);
 }
 
 body.dark-theme .main-footer a:hover,
@@ -116,72 +130,140 @@ body.dark-theme #preloader {
 }
 
 .theme-toggle-container {
-  margin-right: 1.5rem;
+  margin-right: 1.25rem;
 }
 
 .theme-toggle-btn {
+  --toggle-padding: 0.45rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  padding: 0.55rem 1.1rem;
+  gap: 0.75rem;
+  padding: calc(var(--toggle-padding) + 0.05rem) calc(var(--toggle-padding) * 2);
   border-radius: 999px;
-  border: none;
-  background: linear-gradient(120deg, #22d3ee, #6366f1);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.78);
   color: #0f172a;
   font-weight: 600;
-  font-size: 0.9rem;
-  letter-spacing: 0.02em;
-  box-shadow: 0 12px 25px rgba(99, 102, 241, 0.35);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  font-size: 0.83rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease,
+    border-color 0.3s ease, color 0.3s ease;
   cursor: pointer;
 }
 
-.theme-toggle-btn:hover,
-.theme-toggle-btn:focus {
+.theme-toggle-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 14px 30px rgba(56, 189, 248, 0.35);
-  outline: none;
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.14);
 }
 
 .theme-toggle-btn:active {
   transform: translateY(0);
 }
 
-.theme-toggle-btn .theme-icon {
-  font-size: 1.05rem;
-  transition: transform 0.3s ease, opacity 0.3s ease;
+.theme-toggle-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.4);
 }
 
-.theme-toggle-btn .theme-toggle-label {
-  text-transform: uppercase;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
+body.dark-theme .theme-toggle-btn {
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--atlas-dark-text);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 22px 46px rgba(2, 6, 23, 0.55);
 }
 
-.theme-toggle-btn[data-theme-state="dark"] {
-  background: linear-gradient(120deg, #f97316, #facc15);
+body.dark-theme .theme-toggle-btn:hover {
+  box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
+}
+
+.theme-toggle-visual {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 74px;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  background: var(--atlas-toggle-track-light);
+  box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.12);
+  isolation: isolate;
+}
+
+body.dark-theme .theme-toggle-visual {
+  background: var(--atlas-toggle-track-dark);
+  box-shadow: inset 0 1px 4px rgba(2, 6, 23, 0.35);
+}
+
+.theme-toggle-switch {
+  position: absolute;
+  z-index: 1;
+  top: 4px;
+  left: 4px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--atlas-toggle-thumb-light);
+  box-shadow: 0 8px 18px rgba(249, 200, 39, 0.45);
+  transition: transform 0.45s cubic-bezier(0.4, 0, 0.2, 1), background 0.4s ease,
+    box-shadow 0.4s ease;
+  pointer-events: none;
+}
+
+.theme-toggle-btn[data-theme-state="dark"] .theme-toggle-switch {
+  transform: translateX(34px);
+  background: var(--atlas-toggle-thumb-dark);
+  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.45);
+}
+
+.theme-toggle-icon {
+  position: relative;
+  z-index: 2;
+  font-size: 0.95rem;
+  transition: color 0.3s ease, opacity 0.3s ease, transform 0.4s ease;
+}
+
+.theme-icon-sun {
+  color: #f59e0b;
+}
+
+.theme-icon-moon {
   color: #1f2937;
-  box-shadow: 0 12px 25px rgba(250, 204, 21, 0.25);
 }
 
-.theme-toggle-btn[data-theme-state="dark"] .theme-icon-sun {
-  opacity: 0.4;
-  transform: scale(0.85);
-}
-
-.theme-toggle-btn[data-theme-state="light"] .theme-icon-moon {
-  opacity: 0.45;
-  transform: scale(0.85);
-}
-
-.theme-toggle-btn[data-theme-state="dark"] .theme-icon-moon,
 .theme-toggle-btn[data-theme-state="light"] .theme-icon-sun {
   opacity: 1;
   transform: scale(1);
 }
 
-body.dark-theme .theme-toggle-btn {
-  color: #0f172a;
+.theme-toggle-btn[data-theme-state="light"] .theme-icon-moon {
+  opacity: 0.55;
+  transform: scale(0.9);
+  color: #334155;
+}
+
+.theme-toggle-btn[data-theme-state="dark"] .theme-icon-sun {
+  opacity: 0.45;
+  transform: scale(0.9);
+}
+
+.theme-toggle-btn[data-theme-state="dark"] .theme-icon-moon {
+  opacity: 1;
+  transform: scale(1);
+  color: #60a5fa;
+}
+
+.theme-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  letter-spacing: 0.12em;
+  font-size: 0.74rem;
+}
+
+body.dark-theme .theme-toggle-label {
+  color: var(--atlas-dark-text);
 }
 
 .theme-toggle-mobile {
@@ -191,9 +273,31 @@ body.dark-theme .theme-toggle-btn {
 .theme-toggle-mobile .theme-toggle-btn {
   width: 100%;
   justify-content: center;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.85rem;
+  gap: 0.9rem;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(15, 23, 42, 0.06);
   box-shadow: none;
+}
+
+body.dark-theme .theme-toggle-mobile .theme-toggle-btn {
+  background: rgba(15, 23, 42, 0.85);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.theme-toggle-mobile .theme-toggle-label {
+  letter-spacing: 0.18em;
+}
+
+@media (max-width: 1199px) {
+  .theme-toggle-btn {
+    font-size: 0.78rem;
+  }
+
+  .theme-toggle-label {
+    letter-spacing: 0.1em;
+  }
 }
 
 @media (max-width: 991px) {
@@ -202,10 +306,22 @@ body.dark-theme .theme-toggle-btn {
   }
 }
 
+@media (max-width: 480px) {
+  .theme-toggle-mobile .theme-toggle-btn {
+    padding: 0.6rem 0.7rem;
+    gap: 0.75rem;
+  }
+
+  .theme-toggle-mobile .theme-toggle-label {
+    letter-spacing: 0.16em;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   body,
   .theme-toggle-btn,
-  .theme-toggle-btn .theme-icon {
-    transition: none;
+  .theme-toggle-btn .theme-toggle-switch,
+  .theme-toggle-btn .theme-toggle-icon {
+    transition: none !important;
   }
 }

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -5,6 +5,23 @@
     return;
   }
 
+  const storage = {
+    get() {
+      try {
+        return window.localStorage.getItem(STORAGE_KEY);
+      } catch (error) {
+        return null;
+      }
+    },
+    set(value) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, value);
+      } catch (error) {
+        // Silently ignore when storage is not available (private mode, etc.)
+      }
+    },
+  };
+
   const prefersDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
 
   const applyTheme = (theme) => {
@@ -17,12 +34,12 @@
     });
   };
 
-  const storedTheme = localStorage.getItem(STORAGE_KEY);
+  const storedTheme = storage.get();
   const initialTheme = storedTheme || (prefersDark && prefersDark.matches ? 'dark' : 'light');
   applyTheme(initialTheme);
 
   const saveTheme = (theme) => {
-    localStorage.setItem(STORAGE_KEY, theme);
+    storage.set(theme);
   };
 
   toggles.forEach((toggle) => {
@@ -36,7 +53,7 @@
 
   if (prefersDark) {
     const mediaListener = (event) => {
-      if (!localStorage.getItem(STORAGE_KEY)) {
+      if (!storage.get()) {
         applyTheme(event.matches ? 'dark' : 'light');
       }
     };

--- a/templates/index-2.html
+++ b/templates/index-2.html
@@ -146,9 +146,12 @@
 
                     <li class="theme-toggle-mobile d-block d-lg-none">
                         <button type="button" class="theme-toggle-btn" data-theme-toggle aria-label="{% trans 'Переключить тему' %}">
-                            <i class="fa-solid fa-sun theme-icon theme-icon-sun" aria-hidden="true"></i>
+                            <span class="theme-toggle-visual" aria-hidden="true">
+                                <i class="fa-solid fa-sun theme-icon theme-icon-sun"></i>
+                                <span class="theme-toggle-switch"></span>
+                                <i class="fa-solid fa-moon theme-icon theme-icon-moon"></i>
+                            </span>
                             <span class="theme-toggle-label">{% trans 'Тема' %}</span>
-                            <i class="fa-solid fa-moon theme-icon theme-icon-moon" aria-hidden="true"></i>
                         </button>
                     </li>
 
@@ -184,9 +187,12 @@
 
                                 <div class="theme-toggle-container d-none d-lg-flex align-items-center">
                                         <button type="button" class="theme-toggle-btn" data-theme-toggle aria-label="{% trans 'Переключить тему' %}">
-                                                <i class="fa-solid fa-sun theme-icon theme-icon-sun" aria-hidden="true"></i>
+                                                <span class="theme-toggle-visual" aria-hidden="true">
+                                                        <i class="fa-solid fa-sun theme-icon theme-icon-sun"></i>
+                                                        <span class="theme-toggle-switch"></span>
+                                                        <i class="fa-solid fa-moon theme-icon theme-icon-moon"></i>
+                                                </span>
                                                 <span class="theme-toggle-label">{% trans 'Темный режим' %}</span>
-                                                <i class="fa-solid fa-moon theme-icon theme-icon-moon" aria-hidden="true"></i>
                                         </button>
                                 </div>
 


### PR DESCRIPTION
## Summary
- add a prominent theme toggle button in the header for desktop and mobile
- introduce dedicated styling for dark mode and toggle button polish
- implement persistent theme selection with localStorage and system preference fallback

## Testing
- `python manage.py check` *(fails: ImportError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_68d5c93193a0832da3f7e57f8aab19c5