### PR TITLE
Redesign frontend with modern theme and dark mode

### DIFF
--- a/static/css/atlas-theme.css
+++ b/static/css/atlas-theme.css
@@ -1,0 +1,1152 @@
+:root {
+  color-scheme: light;
+  --background: #f5f7fb;
+  --surface: #ffffff;
+  --surface-soft: #f1f4ff;
+  --surface-strong: #e6ecff;
+  --text-primary: #0c1c3f;
+  --text-secondary: #667299;
+  --accent: #0f8df2;
+  --accent-strong: #005dc1;
+  --accent-soft: rgba(15, 141, 242, 0.08);
+  --warning: #f59e0b;
+  --success: #22c55e;
+  --border: rgba(15, 35, 75, 0.08);
+  --shadow-soft: 0 24px 60px rgba(15, 23, 42, 0.12);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition: all 0.35s ease;
+  --hero-gradient: linear-gradient(135deg, #0f8df2 0%, #5622ff 100%);
+  --glass: rgba(255, 255, 255, 0.7);
+  --glass-border: rgba(255, 255, 255, 0.45);
+  --glass-blur: 16px;
+  --nav-height: 92px;
+  font-family: "Manrope", "Inter", "Segoe UI", sans-serif;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --background: #060a17;
+  --surface: #0b1224;
+  --surface-soft: rgba(88, 105, 255, 0.06);
+  --surface-strong: rgba(88, 105, 255, 0.12);
+  --text-primary: #f2f4ff;
+  --text-secondary: #97a3c7;
+  --accent: #69b7ff;
+  --accent-strong: #3b82f6;
+  --accent-soft: rgba(105, 183, 255, 0.14);
+  --border: rgba(105, 183, 255, 0.2);
+  --shadow-soft: 0 24px 65px rgba(4, 14, 35, 0.55);
+  --hero-gradient: radial-gradient(circle at 10% 20%, rgba(30, 64, 255, 0.75), rgba(12, 12, 50, 0.95));
+  --glass: rgba(13, 23, 42, 0.8);
+  --glass-border: rgba(117, 143, 255, 0.24);
+  --glass-blur: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text-primary);
+  font-family: var(--font-family);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  min-height: 100vh;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+a:hover {
+  color: var(--accent-strong);
+}
+
+ul, li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.page-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Preloader */
+#preloader {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: var(--background);
+  z-index: 9999;
+  transition: opacity 0.4s ease;
+}
+
+.preloader-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  background: var(--glass);
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.preloader-content .logo {
+  width: clamp(120px, 18vw, 220px);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+.preloader-content span {
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 14px;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: scale(0.95);
+    opacity: 0.75;
+  }
+  50% {
+    transform: scale(1.02);
+    opacity: 1;
+  }
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 800;
+  backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--border);
+}
+
+[data-theme="dark"] .site-header {
+  background: rgba(8, 13, 30, 0.8);
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 4vw;
+  background: var(--surface-soft);
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.top-bar a {
+  color: inherit;
+}
+
+.top-bar .top-links {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.top-bar .socials {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.top-bar .socials a {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.top-bar .socials a:hover {
+  transform: translateY(-2px);
+  background: var(--accent);
+  color: #fff;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 4vw;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 20px;
+  color: var(--text-primary);
+}
+
+.logo img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+
+.nav-links a {
+  font-weight: 600;
+  color: var(--text-secondary);
+  position: relative;
+}
+
+.nav-links a.active,
+.nav-links a:hover {
+  color: var(--text-primary);
+}
+
+.nav-links a.active::after,
+.nav-links a:hover::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.nav-dropdown {
+  position: relative;
+}
+
+.nav-dropdown > button {
+  background: none;
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.nav-dropdown:hover > button,
+.nav-dropdown:focus-within > button {
+  color: var(--text-primary);
+}
+
+.dropdown-menu-custom {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  min-width: 220px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nav-dropdown:hover .dropdown-menu-custom,
+.nav-dropdown:focus-within .dropdown-menu-custom {
+  display: flex;
+}
+
+.dropdown-menu-custom a {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.dropdown-menu-custom a:hover {
+  color: var(--text-primary);
+}
+
+.dropdown-heading {
+  display: block;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.theme-toggle {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.theme-toggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.language-switcher {
+  position: relative;
+}
+
+.language-switcher button {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 10px 18px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.language-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 12px);
+  min-width: 160px;
+  padding: 12px;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.language-switcher:hover .language-menu,
+.language-switcher:focus-within .language-menu {
+  display: flex;
+}
+
+.language-menu button {
+  border: none;
+  background: none;
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.language-menu button.active,
+.language-menu button:hover {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.nav-toggle {
+  display: none;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-size: 28px;
+}
+
+@media (max-width: 1024px) {
+  .navbar {
+    flex-wrap: wrap;
+    gap: 18px;
+  }
+  .nav-links {
+    order: 3;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 20px;
+    display: none;
+  }
+  .nav-links.open {
+    display: flex;
+  }
+  .nav-dropdown {
+    width: 100%;
+  }
+  .dropdown-menu-custom {
+    position: static;
+    display: none !important;
+    padding-left: 12px;
+    border: none;
+    box-shadow: none;
+  }
+  .nav-dropdown.open .dropdown-menu-custom {
+    display: flex !important;
+  }
+  .language-switcher button {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .nav-toggle {
+    display: block;
+  }
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 12px 24px;
+  font-weight: 600;
+  font-size: 15px;
+  border: none;
+  cursor: pointer;
+  transition: var(--transition);
+  gap: 8px;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  box-shadow: 0 18px 35px rgba(15, 141, 242, 0.28);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 48px rgba(15, 141, 242, 0.4);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+
+.btn-outline:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* Hero */
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 140px;
+  background: var(--hero-gradient);
+  color: #fff;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), transparent 55%),
+              radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.15), transparent 60%);
+  opacity: 0.6;
+}
+
+.hero .container {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 48px;
+  padding: 0 4vw;
+}
+
+.hero-content h1 {
+  font-size: clamp(36px, 5vw, 56px);
+  margin-bottom: 18px;
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.hero-content p {
+  font-size: clamp(18px, 2.2vw, 20px);
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 32px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  align-items: center;
+}
+
+.hero-card {
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  color: var(--text-primary);
+}
+
+.hero-card h3 {
+  color: var(--text-primary);
+  margin-bottom: 18px;
+  font-size: 20px;
+}
+
+.hero-card form {
+  display: grid;
+  gap: 14px;
+}
+
+.input-group {
+  position: relative;
+}
+
+.input-group input {
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-primary);
+  font-size: 16px;
+  transition: var(--transition);
+}
+
+.input-group input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(15, 141, 242, 0.15);
+}
+
+.helper-text {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.hero-stats {
+  display: grid;
+  gap: 18px;
+  margin-top: 32px;
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  padding: 18px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.stat-card strong {
+  font-size: 20px;
+}
+
+/* Generic sections */
+.section {
+  padding: 100px 0;
+}
+
+.section .container {
+  padding: 0 4vw;
+}
+
+.section-header {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 48px;
+}
+
+.section-header h2 {
+  font-size: clamp(30px, 4vw, 40px);
+  margin-bottom: 12px;
+}
+
+.section-header p {
+  color: var(--text-secondary);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.feature-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.feature-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, transparent, rgba(15, 141, 242, 0.08));
+  opacity: 0;
+  transition: var(--transition);
+}
+
+.feature-card:hover::after {
+  opacity: 1;
+}
+
+.feature-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  margin-bottom: 18px;
+}
+
+.feature-card h3 {
+  margin-bottom: 12px;
+  font-size: 18px;
+}
+
+.feature-card p {
+  color: var(--text-secondary);
+  margin-bottom: 0;
+}
+
+/* Rates */
+.rates-section {
+  background: var(--surface-soft);
+}
+
+.rates-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.rate-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.rate-card.hot {
+  border: 1px solid rgba(244, 158, 11, 0.35);
+  box-shadow: 0 26px 46px rgba(245, 158, 11, 0.22);
+}
+
+.rate-card .badge {
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.rate-card.hot .badge {
+  background: rgba(245, 158, 11, 0.14);
+  color: var(--warning);
+}
+
+.price-tag {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.price-tag span {
+  font-size: 15px;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.rate-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 15px;
+}
+
+.rate-card .btn {
+  margin-top: auto;
+}
+
+/* Journey */
+.journey-section {
+  position: relative;
+}
+
+.timeline {
+  display: grid;
+  gap: 32px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.timeline-step {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 16px;
+  align-items: center;
+}
+
+.timeline-step .dot {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  font-weight: 700;
+  border: 1px solid var(--border);
+  position: relative;
+}
+
+.timeline-step.active .dot {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 16px 38px rgba(15, 141, 242, 0.25);
+}
+
+.timeline-step p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+/* Addresses */
+.addresses-section {
+  background: var(--surface);
+}
+
+.address-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.address-card {
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
+  backdrop-filter: blur(8px);
+  display: grid;
+  gap: 12px;
+}
+
+.address-card h4 {
+  margin: 0;
+}
+
+.address-card span {
+  color: var(--text-secondary);
+}
+
+/* CTA */
+.cta-section {
+  padding: 110px 0;
+  position: relative;
+}
+
+.cta-card {
+  max-width: 840px;
+  margin: 0 auto;
+  background: var(--hero-gradient);
+  color: #fff;
+  padding: 48px;
+  border-radius: var(--radius-lg);
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.cta-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.25), transparent 50%);
+  opacity: 0.5;
+}
+
+.cta-card h2 {
+  font-size: clamp(28px, 4vw, 36px);
+  margin-bottom: 12px;
+  position: relative;
+  z-index: 2;
+}
+
+.cta-card p {
+  color: rgba(255, 255, 255, 0.88);
+  position: relative;
+  z-index: 2;
+  margin-bottom: 32px;
+}
+
+.cta-card .btn {
+  position: relative;
+  z-index: 2;
+}
+
+/* Footer */
+.site-footer {
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  padding: 48px 4vw;
+  color: var(--text-secondary);
+  margin-top: auto;
+}
+
+.site-footer .footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 32px;
+}
+
+.site-footer h4 {
+  color: var(--text-primary);
+  margin-bottom: 18px;
+}
+
+.site-footer ul {
+  display: grid;
+  gap: 8px;
+}
+
+.site-footer .footer-bottom {
+  margin-top: 32px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* Tracking timeline for details page */
+.tracking-wrapper {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--surface);
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+}
+
+.tracking-steps {
+  position: relative;
+  padding-left: 32px;
+  margin-top: 32px;
+}
+
+.tracking-steps::before {
+  content: "";
+  position: absolute;
+  left: 16px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--surface-strong);
+}
+
+.track-step {
+  position: relative;
+  margin-bottom: 28px;
+  padding-left: 28px;
+}
+
+.track-step:last-child {
+  margin-bottom: 0;
+}
+
+.track-step::before {
+  content: "";
+  position: absolute;
+  left: -18px;
+  top: 6px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 3px solid var(--surface);
+  background: var(--surface-strong);
+  box-shadow: 0 0 0 4px rgba(15, 141, 242, 0.12);
+}
+
+.track-step.completed::before {
+  background: var(--success);
+  border-color: rgba(34, 197, 94, 0.25);
+}
+
+.track-step.active::before {
+  background: var(--accent);
+  border-color: rgba(15, 141, 242, 0.3);
+}
+
+.track-step h4 {
+  margin: 0 0 6px;
+}
+
+.track-step span {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.info-card {
+  display: grid;
+  gap: 12px;
+  padding: 24px;
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+}
+
+.info-card strong {
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.alert-custom {
+  padding: 18px 24px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 97, 97, 0.25);
+  background: rgba(255, 97, 97, 0.12);
+  color: #ffb4b4;
+}
+
+/* Forms */
+.form-card {
+  max-width: 520px;
+  margin: 0 auto;
+  background: var(--surface);
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+}
+
+.form-card label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+
+.form-card input,
+.form-card textarea,
+.form-card select {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 14px 16px;
+  font-size: 15px;
+  background: var(--surface-soft);
+  color: var(--text-primary);
+  transition: var(--transition);
+}
+
+.form-card input:focus,
+.form-card textarea:focus,
+.form-card select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(15, 141, 242, 0.15);
+}
+
+.form-card .form-row {
+  display: grid;
+  gap: 16px;
+}
+
+/* Table */
+.table-card {
+  background: var(--surface);
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  overflow-x: auto;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 36px;
+}
+
+.pagination a,
+.pagination span {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.pagination a:hover,
+.pagination .active {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+}
+
+/* Modal */
+.modal-content.my-modal-content {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.modal-header.my-modal-header {
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: #fff;
+}
+
+.modal-footer.my-modal-footer {
+  border-top: 1px solid var(--border);
+  background: var(--surface-soft);
+}
+
+/* Utility */
+.muted {
+  color: var(--text-secondary);
+}
+
+.badge-soft {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.stack {
+  display: grid;
+  gap: 18px;
+}
+
+@media (max-width: 768px) {
+  .top-bar {
+    flex-direction: column;
+    gap: 6px;
+    text-align: center;
+  }
+  .hero {
+    padding: 90px 0 110px;
+  }
+  .hero-card {
+    padding: 22px;
+  }
+  .section {
+    padding: 80px 0;
+  }
+  .cta-card {
+    padding: 38px 28px;
+  }
+  .tracking-wrapper {
+    padding: 24px;
+  }
+  .tracking-steps::before {
+    left: 12px;
+  }
+  .track-step {
+    padding-left: 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .timeline-step {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .timeline-step .dot {
+    margin: 0 auto;
+  }
+  .hero-actions {
+    flex-direction: column;
+  }
+  .hero-card form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -1,100 +1,79 @@
 {% extends 'index-2.html' %}
 {% load static %}
 {% load i18n dict_utils %}
+
 {% block content %}
-    {% if contacts %}
-	<section class="testimonial-section">
-		<div class="auto-container">
-			<div class="sec-title centered">
-				{% if selected_country %}
-				{# Ищем выбранную страну в списке countries #}
-				{% for country in countries %}
-				{% if country.id|stringformat:'s' == selected_country %}
-				<h3>{% trans 'Контакты' %} {{ country.title }}</h3>
-				{% endif %}
-				{% endfor %}
-				{% else %}
-				<h3>{% trans 'Контакты' %}</h3>
-				{% endif %}
-				<div class="separater"></div>
-			</div>
-			<div class="row">
-				{% for address in contacts %}
-				<div class="col-lg-6 col-md-12 mb-4">
-					<div class="testimonial-block blue h-100">
-						<div class="inner-box">
-							<div class="quote-icon flaticon-left-quote"></div>
-							<div class="embed-responsive embed-responsive-16by9 mb-3">
-								<iframe
-										class="embed-responsive-item"
-										src="https://www.google.com/maps?q={{ address.coordinates1 }}&hl=ru&z=14&output=embed"
-										allowfullscreen
-										loading="lazy"
-										style="border:0;">
-								</iframe>
-							</div>
-							<div class="author-info">
-								<div class="info-inner">
-									{% if address.city and address.city.country and address.city.country.photo %}
-									<div class="author-image">
-										<img src="{{ address.city.country.photo.url }}" alt=""/>
-									</div>
-									{% endif %}
-									<div>
-										<h5 class="mb-1">{{ address.country.title }}</h5>
-										<div class="designation">{{ address.title }}</div>
-										<div class="designation">{{ address.city }}</div>
-										<div class="designation">📞 {{ address.phone }}
-										</div>
-									</div>
-								</div>
-							</div>
-							<br>
-						</div>
-					</div>
-				</div>
+<section class="section" id="contacts">
+    <div class="container">
+        <div class="section-header">
+            <span class="chip"><i class="fa-solid fa-handshake"></i> {% trans 'Контакты' %}</span>
+            {% if selected_country %}
+                {% for country in countries %}
+                    {% if country.id|stringformat:'s' == selected_country %}
+                        <h2>{% trans 'Представительства в стране' %} «{{ country.title }}»</h2>
+                    {% endif %}
+                {% endfor %}
+            {% else %}
+                <h2>{% trans 'Все контакты Atlas Express' %}</h2>
+            {% endif %}
+            <p>{% trans 'Выберите ближайший офис или пункт выдачи и свяжитесь с менеджером для уточнения деталей.' %}</p>
+        </div>
 
-				{% endfor %}
-			</div>
+        {% if contacts %}
+            <div class="address-grid">
+                {% for address in contacts %}
+                    <article class="address-card">
+                        {% if address.city and address.city.country %}
+                            <span class="badge-soft">{{ address.city.country.title }}</span>
+                        {% endif %}
+                        <h4>{{ address.title }}</h4>
+                        {% if address.city %}
+                            <span><i class="fa-solid fa-location-dot"></i> {{ address.city }}</span>
+                        {% endif %}
+                        <span><i class="fa-solid fa-phone"></i> {{ address.phone }}</span>
+                        {% if address.phone2 %}
+                            <span class="muted">{% trans 'Доп. номер:' %} {{ address.phone2 }}</span>
+                        {% endif %}
+                        {% if address.coordinates1 %}
+                            <a class="btn btn-outline" href="https://www.google.com/maps?q={{ address.coordinates1 }}" target="_blank" rel="noopener">
+                                <i class="fa-solid fa-map"></i> {% trans 'Открыть карту' %}
+                            </a>
+                        {% endif %}
+                        {% if address.coordinates2 %}
+                            <a class="btn btn-outline" href="https://www.google.com/maps?q={{ address.coordinates2 }}" target="_blank" rel="noopener">
+                                <i class="fa-solid fa-location-arrow"></i> {% trans 'Маршрут' %}
+                            </a>
+                        {% endif %}
+                    </article>
+                {% endfor %}
+            </div>
 
-			{% if is_paginated %}
-			<ul class="styled-pagination text-center">
+            {% if is_paginated %}
+                <div class="pagination">
+                    {% if page_obj.has_previous %}
+                        <a href="?page={{ page_obj.previous_page_number }}{% if request.GET.country %}&country={{ request.GET.country }}{% endif %}{% if request.GET.city %}&city={{ request.GET.city }}{% endif %}" aria-label="{% trans 'Предыдущая страница' %}">
+                            <i class="fa-solid fa-chevron-left"></i>
+                        </a>
+                    {% endif %}
 
-				{# Кнопка "назад" #}
-				{% if page_obj.has_previous %}
-				<li class="prev">
-					<a href="?page={{ page_obj.previous_page_number }}{% if request.GET.country %}&country={{ request.GET.country }}{% endif %}{% if request.GET.city %}&city={{ request.GET.city }}{% endif %}">
-						<span class="fa fa-angle-left"></span>
-					</a>
-				</li>
-				{% endif %}
+                    {% for page_num in paginator.page_range %}
+                        {% if page_obj.number == page_num %}
+                            <span class="active">{{ page_num }}</span>
+                        {% else %}
+                            <a href="?page={{ page_num }}{% if request.GET.country %}&country={{ request.GET.country }}{% endif %}{% if request.GET.city %}&city={{ request.GET.city }}{% endif %}">{{ page_num }}</a>
+                        {% endif %}
+                    {% endfor %}
 
-				{# Список страниц #}
-				{% for page_num in paginator.page_range %}
-				{% if page_obj.number == page_num %}
-				<li><a class="active" href="#">{{ page_num }}</a></li>
-				{% else %}
-				<li>
-					<a href="?page={{ page_num }}{% if request.GET.country %}&country={{ request.GET.country }}{% endif %}{% if request.GET.city %}&city={{ request.GET.city }}{% endif %}">
-						{{ page_num }}
-					</a>
-				</li>
-				{% endif %}
-				{% endfor %}
-
-				{# Кнопка "вперёд" #}
-				{% if page_obj.has_next %}
-				<li class="next">
-					<a href="?page={{ page_obj.next_page_number }}{% if request.GET.country %}&country={{ request.GET.country }}{% endif %}{% if request.GET.city %}&city={{ request.GET.city }}{% endif %}">
-						<span class="fa fa-angle-right"></span>
-					</a>
-				</li>
-				{% endif %}
-
-			</ul>
-			{% endif %}
-		</div>
-	</section>
-	<!-- End Testimonial Section -->
-	{% endif %}
+                    {% if page_obj.has_next %}
+                        <a href="?page={{ page_obj.next_page_number }}{% if request.GET.country %}&country={{ request.GET.country }}{% endif %}{% if request.GET.city %}&city={{ request.GET.city }}{% endif %}" aria-label="{% trans 'Следующая страница' %}">
+                            <i class="fa-solid fa-chevron-right"></i>
+                        </a>
+                    {% endif %}
+                </div>
+            {% endif %}
+        {% else %}
+            <div class="text-center muted">{% trans 'Контактная информация временно недоступна.' %}</div>
+        {% endif %}
+    </div>
+</section>
 {% endblock %}

--- a/templates/id_details.html
+++ b/templates/id_details.html
@@ -3,207 +3,128 @@
 {% load i18n dict_utils %}
 
 {% block content %}
-<style>
-  /* ...тут тот же CSS, что и у тебя... */
-  .tracking-container{ position:relative; margin:0 auto; }
-  .tracking-line{ position:absolute; left:50%; top:0; bottom:0; width:4px; background:#ccc; transform:translateX(-50%); z-index:1; }
-  .tracking-step{ position:relative; margin:60px 0; }
-  .tracking-circle{ position:absolute; left:50%; transform:translateX(-50%); width:35px; height:35px; border-radius:50%; background:#ccc; border:4px solid #fff; z-index:2; }
-  .tracking-step.completed .tracking-circle{ background:#28a745; }
-  .tracking-step.comp-blue .tracking-circle{ background:#fff; }
-  .tracking-step.comp-blue .tracking-circle::before{ content:''; position:absolute; top:0; left:0; right:0; bottom:0; background:#1b8af3; border-radius:50%; z-index:-1; animation: blink 1.5s infinite; }
-  @keyframes blink { 0%{opacity:1} 50%{opacity:0.3} 100%{opacity:1} }
-  .step-label{ position:relative; left:calc(50% + 35px); font-size:16px; color:#333; white-space:nowrap; }
-  .step-time { color:#8d8d8d; }
-  @media(max-width:480px){
-    .step-label{ font-size:12px; left:auto; right:calc(50% + 25px); text-align:right; }
-    .step-time{ font-size:10px; }
-  }
-</style>
-<style>
-  .tracking-circle {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 2px solid #ccc;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-}
-
-.tracking-step.completed .tracking-circle {
-  background-color: #28a745; /* зелёный */
-  border-color: #28a745;
-  color: #fff;
-}
-
-</style>
-<div class="sidebar-page-container" style="background-color: white;">
-  <div class="auto-container">
-    <div class="row clearfix">
-      <!--Content Side-->
-      <div class="content-side col-lg-12 col-md-12 col-sm-12">
-        <div class="track-section">
-          <div class="sec-title-two sec-title">
-            <h2>{% trans 'Поиск' %} &amp; <span>{% trans 'отслеживаение посылок' %}</span></h2>
-          </div>
-
-          <div class="quote-form-box"></div>
-
-          <div class="track-form-two">
-            <form method="post" style="background-color: white; padding: 20px; border-radius: 8px;">
-              {% csrf_token %}
-              <div class="form-group">
-                <label>{% trans 'Пожалуйста, введите ID посылки' %}</label>
-              </div>
-              <div class="form-group">
-                <input type="text" name="trackid" placeholder="Id" required>
-                <button type="submit" class="theme-btn submit-btn">{% trans 'Поиск' %}</button>
-              </div>
-            </form>
-          </div>
-
-          {# Показываем шкалу только если есть data (защищаемся от обращения к data.* когда его нет) #}
-          {% if data %}
-          <div class="container">
-            <div class="row">
-              <div class="col-12 col-md-4">
-                <div class="tracking-container">
-                  <div class="tracking-line"></div>
-
-{% for code, label in steps %}
-  {% if code != "delivered" %}
-    <div class="tracking-step{% if current_index != -1 and forloop.counter0 < current_index %} completed{% elif current_index != -1 and forloop.counter0 == current_index and data.status != 'delivered' %} comp-blue{% endif %}">
-<div class="tracking-circle">
-  {% if current_index != -1 and forloop.counter0 < current_index %}
-    <i class="fa-solid fa-check"></i>
-  {% endif %}
-</div>
-      <div class="step-label">
-        {% trans label %}
-        <div class="step-time">
-          {% if current_index != -1 and forloop.counter0 < current_index %}
-            {% trans "Прошло" %}
-          {% elif code == "accept_location" and current_index != -1 and forloop.counter0 >= current_index %}
-            {{ data.arrival_range|default:"—" }}
-          {% elif current_index != -1 and forloop.counter0 == current_index and data.status != "delivered" %}
-            {% if data.currentLocation.name %}
-              {{ data.currentLocation.name }}
-            {% elif data.currentLocation.address %}
-              {{ data.currentLocation.address }}
-            {% else %}
-              —
-            {% endif %}
-          {% else %}
-            {% trans "Ожидается" %}
-          {% endif %}
+<section class="section" id="tracking-details">
+    <div class="container">
+        <div class="section-header">
+            <span class="chip"><i class="fa-solid fa-compass"></i> {% trans 'Отслеживание' %}</span>
+            <h2>{% trans 'Подробный статус доставки' %}</h2>
+            <p>{% trans 'Следите за каждым этапом движения посылки. Обновления подтягиваются автоматически из системы Atlas Express.' %}</p>
         </div>
-      </div>
-    </div>
-  {% endif %}
-{% endfor %}
 
-                  {# добавляем финальный шаг только если статус доставлено #}
-                  {% if data.status == "delivered" %}
-  <div class="tracking-step completed">
-    <div class="tracking-circle">
-      <i class="fa-solid fa-check"></i>
-    </div>
-    <div class="step-label">
-      {% trans "Доставлено" %}
-      <div class="step-time">{{ data.updatedDateOnly }}</div>
-    </div>
-  </div>
-{% endif %}
-
+        <div class="form-card" style="margin-bottom: 40px;">
+            <form method="post" class="track-form" action="{% url 'tracking_details' %}">
+                {% csrf_token %}
+                <div class="form-row">
+                    <label for="track-id">{% trans 'Введите ID посылки' %}</label>
+                    <input id="track-id" type="text" name="trackid" value="{{ trackid }}" placeholder="{% trans 'Например, AT-458921' %}" required>
                 </div>
-              </div>
-            </div>
-          </div>
-          {% endif %} {# конец if data для шкалы #}
-
-          <div class="map-outer"></div>
-
+                <div class="form-row">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-magnifying-glass"></i> {% trans 'Обновить статус' %}
+                    </button>
+                </div>
+            </form>
+            {% if error %}
+                <div class="alert alert-warning mt-3" role="alert">{{ error }}</div>
+            {% endif %}
         </div>
-      </div>
-      <!--/Content Side-->
-    </div>
-          {% if data %}
-<div class="d-flex justify-content-center align-items-center" style="min-height: 80vh;">
-  <div class="card shadow-lg w-100" style="max-width: 520px; font-size: 1.1rem;">
-    <div class="card-header text-center font-weight-bold text-white" style="font-size: 1.3rem; background-color: #005e93;">
-      🔎 {% trans 'Номер счета:' %} {{ data.id }}
-    </div>
-    <div class="card-body">
-      <h5 class="card-title mb-3" style="font-size: 1.25rem;">
-        {% trans 'Ваш тариф:' %} <span class="font-weight-bold">{{ data.shipmentType.name }}</span>
-      </h5>
 
-      <p class="mb-3" style="font-size: 1.15rem;">
-        📦 <strong>{% trans 'Статус:' %}</strong>
-        {% if data.status == "in_warehouse" %}
-          {% trans "На складе" %}
-        {% elif data.status == "location" %}
-          {% trans "Местоположение" %}
-        {% elif data.status == "packed" %}
-          {% trans "Упакован" %}
-        {% elif data.status == "shipped" %}
-          {% trans "Отправлен" %}
-        {% elif data.status == "in_customs" %}
-          {% trans "На таможне" %}
-        {% elif data.status == "arrive_warehouse" %}
-          {% trans "Прибыл на склад" %}
-        {% elif data.status == "accept_location" %}
-          {% trans "Принято в местоположение" %}
-        {% elif data.status == "delivered" %}
-          {% trans "Доставлено" %}
+        {% if data %}
+            <div class="tracking-wrapper">
+                <div class="stack" style="margin-bottom: 24px;">
+                    <div class="info-card">
+                        <strong>{% trans 'Номер отправления' %}</strong>
+                        <span class="h4 mb-0">{{ data.id }}</span>
+                        <span class="muted">{% trans 'Последнее обновление:' %} {{ data.updatedAt }}</span>
+                    </div>
+                    <div class="info-card">
+                        <strong>{% trans 'Тип отправления' %}</strong>
+                        <span>{{ data.shipmentType.name|default:'—' }}</span>
+                        {% if data.weight %}
+                            <span class="muted">{% trans 'Вес:' %} {{ data.weight }} кг</span>
+                        {% endif %}
+                    </div>
+                    <div class="info-card">
+                        <strong>{% trans 'Текущий статус' %}</strong>
+                        <span>
+                            {% if data.status == "in_warehouse" %}
+                                {% trans "На складе" %}
+                            {% elif data.status == "location" %}
+                                {% trans "Местоположение" %}
+                            {% elif data.status == "packed" %}
+                                {% trans "Упакован" %}
+                            {% elif data.status == "shipped" %}
+                                {% trans "Отправлен" %}
+                            {% elif data.status == "in_customs" %}
+                                {% trans "На таможне" %}
+                            {% elif data.status == "arrive_warehouse" %}
+                                {% trans "Прибыл на склад" %}
+                            {% elif data.status == "accept_location" %}
+                                {% trans "Принято в местоположение" %}
+                            {% elif data.status == "out_location" %}
+                                {% trans "Вышел из местоположения" %}
+                            {% elif data.status == "delivered" %}
+                                {% trans "Доставлено" %}
+                            {% else %}
+                                {{ data.status }}
+                            {% endif %}
+                        </span>
+                        {% if data.currentLocation.address or data.currentLocation.name %}
+                            <span class="muted">{% trans 'Текущее местоположение:' %} {{ data.currentLocation.name|default:data.currentLocation.address }}</span>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="tracking-steps">
+                    {% for code, label in steps %}
+                        {% if code != 'delivered' or data.status == 'delivered' %}
+                            {% with idx=forloop.counter0 %}
+                                <div class="track-step{% if current_index != -1 and idx < current_index %} completed{% endif %}{% if current_index != -1 and idx == current_index %} active{% endif %}">
+                                    <h4>{{ label }}</h4>
+                                    <span>
+                                        {% if current_index == -1 %}
+                                            {% trans 'Ожидается обновление' %}
+                                        {% elif idx < current_index %}
+                                            {% trans 'Выполнено' %}
+                                        {% elif idx == current_index and code == 'accept_location' and data.arrival_range %}
+                                            {{ data.arrival_range }}
+                                        {% elif idx == current_index and data.status == 'delivered' %}
+                                            {{ data.updatedDateOnly }} {{ data.updatedDateOnlyTime }}
+                                        {% elif idx == current_index %}
+                                            {{ data.currentLocation.name|default:data.currentLocation.address|default:_('В процессе') }}
+                                        {% elif code == 'accept_location' and data.arrival_range %}
+                                            {{ data.arrival_range }}
+                                        {% elif code == 'delivered' and data.updatedDateOnly %}
+                                            {{ data.updatedDateOnly }}
+                                        {% else %}
+                                            {% trans 'Ожидается' %}
+                                        {% endif %}
+                                    </span>
+                                </div>
+                            {% endwith %}
+                        {% endif %}
+                    {% endfor %}
+                </div>
+
+                <div class="stack" style="margin-top: 32px;">
+                    {% if data.status != 'delivered' %}
+                        <div class="info-card">
+                            <strong>{% trans 'Ориентировочная доставка' %}</strong>
+                            <span>{{ data.arrival_range|default:_('Дата уточняется') }}</span>
+                        </div>
+                    {% else %}
+                        <div class="info-card">
+                            <strong>{% trans 'Посылка доставлена' %}</strong>
+                            <span>{{ data.updatedDateOnly }} {{ data.updatedDateOnlyTime }}</span>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
         {% else %}
-          {{ data.status }}
+            {% if not error %}
+                <div class="text-center muted">{% trans 'Введите ID посылки, чтобы увидеть детали отслеживания.' %}</div>
+            {% endif %}
         {% endif %}
-      </p>
-
-      {% if data.status != "delivered" %}
-        <p class="mb-3" style="font-size: 1.15rem;">
-          📍 <strong>{% trans 'Текущее местоположение:' %}</strong><br>
-          {{ data.currentLocation.address|default:"—" }}
-        </p>
-        <p style="font-size: 1.15rem;">
-          ⏳ <strong>{% trans 'Доставка будет осуществлена:' %}</strong><br>
-          {{ data.arrival_range|default:"—" }}
-        </p>
-      {% else %}
-        <p style="font-size: 1.15rem;">
-          ✅ <strong>{% trans 'Доставлен:' %}</strong><br>
-          {{ data.updatedDateOnly }}
-        </p>
-      {% endif %}
     </div>
-  </div>
-</div>
-{% endif %}
-  </div>
-</div>
-{% block counter_section %}
-{% endblock %}
-
-{# отдельная карточка с деталями (она у тебя была ниже) #}
-
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    const stepTimes = document.querySelectorAll(".step-time");
-    stepTimes.forEach(function (el) {
-      const text = el.textContent.trim();
-      if (text.length > 20) {
-        const spaceIndex = text.indexOf(" ", 20);
-        if (spaceIndex !== -1) {
-          const firstLine = text.slice(0, spaceIndex);
-          const secondLine = text.slice(spaceIndex + 1);
-          el.innerHTML = firstLine + "<br>" + secondLine;
-        }
-      }
-    });
-  });
-</script>
-
+</section>
 {% endblock %}

--- a/templates/id_search_form.html
+++ b/templates/id_search_form.html
@@ -3,25 +3,30 @@
 {% load i18n dict_utils %}
 
 {% block content %}
-<div class="tracking-form">
-    <form method="post" style="background-color: white; padding: 20px; border-radius: 8px;">
-        {% csrf_token %}
-
-        <div class="form-group">
-            <label>{% trans 'Пожалуйста, введите ID посылки' %}</label>
+<section class="section" id="tracking-form">
+    <div class="container">
+        <div class="section-header">
+            <span class="chip"><i class="fa-solid fa-box"></i> {% trans 'Статус посылки' %}</span>
+            <h2>{% trans 'Проверьте отправление по номеру ID' %}</h2>
+            <p>{% trans 'Введите идентификатор посылки, чтобы узнать последние обновления и ориентировочную дату доставки.' %}</p>
         </div>
-
-        <div class="form-group d-flex">
-            <input class="form-control" type="text" name="trackid" placeholder="ID" required>
-            <button type="submit" class="theme-btn submit-btn ml-2">{% trans 'Поиск' %}</button>
+        <div class="form-card">
+            <form method="post" class="track-form" action="{% url 'tracking_details' %}">
+                {% csrf_token %}
+                <div class="form-row">
+                    <label for="track-id">{% trans 'ID посылки' %}</label>
+                    <input id="track-id" type="text" name="trackid" placeholder="{% trans 'Например, AT-458921' %}" required>
+                </div>
+                <div class="form-row">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-magnifying-glass"></i> {% trans 'Найти посылку' %}
+                    </button>
+                </div>
+            </form>
+            {% if error %}
+                <div class="alert alert-warning mt-3" role="alert">{{ error }}</div>
+            {% endif %}
         </div>
-    </form>
-
-    {% if error %}
-        <div class="alert alert-danger mt-3">
-            {{ error }}
-        </div>
-    {% endif %}
-</div>
-
+    </div>
+</section>
 {% endblock %}

--- a/templates/index-2.html
+++ b/templates/index-2.html
@@ -1,1171 +1,516 @@
 {% load static %}
 {% load i18n dict_utils %}
 <!DOCTYPE html>
-<html>
+<html lang="{{ LANGUAGE_CODE|default:'ru' }}">
 <head>
-<meta charset="utf-8">
-<title>AtlasExpress.uz</title>
-<!-- Stylesheets -->
-<!--<link href="{% static 'css/font-awesome.min.css' %}" rel="stylesheet">-->
-	<link href="{% static 'css/mystyle.css' %}" rel="stylesheet">
-<link href="{% static 'css/bootstrap.css' %}" rel="stylesheet">
-<link href="{% static 'css/style.css' %}" rel="stylesheet">
-<link href="{% static 'css/responsive.css' %}" rel="stylesheet">
-<link rel="shortcut icon" href="{% static 'images/atlas123.png' %}" type="image/x-icon">
-<link rel="icon" href="{% static 'images/atlas123.png' %}" type="image/x-icon">
-
-<!--<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">-->
-<!-- Responsive -->
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<!--[if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script><![endif]-->
-<!--[if lt IE 9]><script src="js/respond.js"></script><![endif]-->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>AtlasExpress.uz</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-HT0xO3UjGJ3q1gETVjaOQAMgKXZb8YdECuLxA0H3U6YzCvtWyLuUy2bkL5ECMhrI6bbUVVdY0Lh9t8bZ7Wl5mQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="{% static 'css/bootstrap.css' %}">
+    <link rel="stylesheet" href="{% static 'css/atlas-theme.css' %}">
+    <link rel="shortcut icon" href="{% static 'images/atlas123.png' %}" type="image/x-icon">
+    <link rel="icon" href="{% static 'images/atlas123.png' %}" type="image/x-icon">
+    {% block extra_styles %}{% endblock %}
 </head>
-
-<body class="hidden-bar-wrapper">
+<body data-theme="light">
 <div id="preloader">
-  <div class="preloader-content">
-    <img src="{% static 'images/atlas33.png' %}" class="logo" alt="AtlasExpress">
-  </div>
-</div>
-
-<style>
-  /* Прелоадер на весь экран */
-  #preloader {
-    position: fixed;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    background-color: #fff;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 99999;
-    overflow: hidden;
-  }
-
-  .preloader-content {
-    position: relative;
-    text-align: center;
-  }
-
-.preloader-content .logo {
-  width: 20vw;        /* занимает 20% ширины экрана */
-  max-width: 200px;   /* но не больше 220px */
-  min-width: 130px;   /* и не меньше 150px */
-  animation: logo-scale-in 1s ease-in-out forwards;
-}
-
-  /* Анимация появления */
-  @keyframes logo-scale-in {
-    0%   { transform: scale(0); opacity: 0; }
-    50%  { transform: scale(1.2); opacity: 1; }
-    100% { transform: scale(1); opacity: 1; }
-  }
-
-  /* Анимация исчезновения */
-  @keyframes logo-scale-out {
-    0%   { transform: scale(1); opacity: 1; }
-    50%  { transform: scale(1.2); opacity: 1; }
-    100% { transform: scale(0.5); opacity: 0; }
-  }
-
-  /* класс для запуска анимации исчезновения */
-  .logo.hide {
-    animation: logo-scale-out 0.7s ease-in-out forwards;
-  }
-</style>
-<!--<style>-->
-<!--  /* Тёмная тема */-->
-<!--  body.dark-theme {-->
-<!--    background-color: #121212;-->
-<!--    color: #e0e0e0;-->
-<!--  }-->
-
-<!--  body.dark-theme a {-->
-<!--    color: #bb86fc;-->
-<!--  }-->
-
-<!--  body.dark-theme .header-top,-->
-<!--  body.dark-theme .header-upper,-->
-<!--  body.dark-theme .main-header,-->
-<!--  body.dark-theme .sticky-header {-->
-<!--    background-color: #1f1f1f;-->
-<!--  }-->
-
-<!--  body.dark-theme .price-block,-->
-<!--  body.dark-theme .inner-column {-->
-<!--    background-color: #1e1e1e;-->
-<!--    color: #e0e0e0;-->
-<!--  }-->
-
-<!--  body.dark-theme .theme-btn {-->
-<!--    background-color: #bb86fc;-->
-<!--    color: #121212;-->
-<!--  }-->
-
-<!--  /* Модальные окна */-->
-<!--  body.dark-theme .my-modal-content {-->
-<!--    background-color: #2c2c2c !important;-->
-<!--    color: #e0e0e0 !important;-->
-<!--  }-->
-<!--</style>-->
-<style>
-  /* Это должно идти **после** всех твоих подключённых CSS */
-  .my-modal-content {
-    background-color: #ffffff !important;
-    border-radius: 12px !important;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.3) !important;
-  }
-  .my-modal-header {
-    background: linear-gradient(135deg, #005e93, #005e93) !important;
-    color: #fff !important;
-    border-top-left-radius: 12px !important;
-    border-top-right-radius: 12px !important;
-  }
-  .my-modal-close {
-    color: #fff !important;
-    opacity: 1 !important;
-  }
-  .my-modal-body {
-    background-color: #ffffff !important;
-    color: #111 !important;
-    font-size: 16px;
-    padding: 20px !important;
-  }
-  .my-modal-footer {
-    background-color: #f0f0f0 !important;
-    border-bottom-left-radius: 12px !important;
-    border-bottom-right-radius: 12px !important;
-  }
-  .modal-backdrop.show {
-    background-color: rgba(0, 0, 0, 0.3) !important;
-    opacity: 1 !important;
-  }
-</style>
-
-
-<div class="page-wrapper">
-
-    <!-- Preloader -->
-    <div class="preloader"></div>
-
- 	<!-- Main Header-->
-    <header class="main-header">
-
-		<!--Header Top-->
-    	<div class="header-top">
-    <div class="auto-container">
-        <div class="clearfix d-flex flex-wrap justify-content-between align-items-center">
-
-            <!-- Top Left -->
-            <div class="top-left d-flex align-items-center">
-                <ul class="social-box d-flex align-items-center flex-wrap mb-0 p-0"
-                    style="gap: 10px; list-style: none; position: relative; z-index: 9999;">
-                    <li>
-                        <a href="https://www.instagram.com/atlasexpress.usa?igsh=MW9nMGgxYjdqdzV3eA==" target="_blank" rel="noopener">
-                            <span class="fa-brands fa-instagram text-white" style="font-size: 18px;"></span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://www.facebook.com/profile.php?id=61561937198092&mibextid=LQQJ4d" target="_blank" rel="noopener">
-                            <span class="fa-brands fa-facebook text-white" style="font-size: 18px;"></span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://t.me/AtlasExpressUS" target="_blank" rel="noopener">
-                            <span class="fa-brands fa-telegram text-white" style="font-size: 18px;"></span>
-                        </a>
-                    </li>
-
-                    {% if LANGUAGE_CODE == 'ru' %}
-                    <li class="d-block d-lg-none">
-                        <a href="/en{{ request.get_full_path|slice:'3:' }}">
-                            <span class="fa fa-globe text-white"></span> RU
-                        </a>
-                    </li>
-                    {% elif LANGUAGE_CODE == 'en' %}
-                    <li class="d-block d-lg-none">
-                        <a href="/ru{{ request.get_full_path|slice:'3:' }}">
-                            <span class="fa fa-globe text-white"></span> EN
-                        </a>
-                    </li>
-                    {% endif %}
-                </ul>
-            </div>
-
-            <!-- Top Right -->
-			<div class="top-right d-flex align-items-center">
-
-				<!-- Скрыто на мобильных, видно только на больших -->
-				<ul class="right-list mb-0 mr-3 d-none d-lg-flex" style="list-style: none;">
-					<li>
-						<span class="icon flaticon-mail"></span> atlasexpressuz@gmail.com
-					</li>
-					<li style="font-size: 14px;">
-<!--						<span class="icon flaticon-phone-contact"></span> +998 77 293 33 00<br>-->
-					</li>
-
-				</ul>
-
-				<!-- Desktop language dropdown -->
-				<div class="dropdown language d-none d-lg-block">
-					<a class="nav-link dropdown-toggle text-white" href="#" id="languageDropdown" role="button"
-					   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						<i class="fa fa-globe text-white"></i>
-						{% if LANGUAGE_CODE == 'ru' %} Русский {% elif LANGUAGE_CODE == 'en' %} English {% endif %}
-						<span class="fa fa-angle-down"></span>
-					</a>
-
-					<div class="dropdown-menu dropdown-menu-right text-right" aria-labelledby="languageDropdown">
-						<form method="post" action="{% url 'set_language' %}" id="language-form">
-							{% csrf_token %}
-							<button type="submit" name="language" value="ru"
-									class="dropdown-item {% if LANGUAGE_CODE == 'ru' %}active{% endif %}">
-								Русский
-							</button>
-							<button type="submit" name="language" value="en"
-									class="dropdown-item {% if LANGUAGE_CODE == 'en' %}active{% endif %}">
-								English
-							</button>
-						</form>
-					</div>
-				</div>
-			</div>
-
-        </div>
+    <div class="preloader-content">
+        <img src="{% static 'images/atlas33.png' %}" class="logo" alt="AtlasExpress">
+        <span>{% trans 'Загрузка интерфейса' %}</span>
     </div>
 </div>
-
-    	<!--Header-Upper-->
-        <div class="header-upper">
-        	<div class="auto-container">
-            	<div class="clearfix">
-                	<div class="pull-left logo-box">
-                    	<div class="logo"><a href="index.html"><img src="images/logo.png" alt="" title=""></a></div>
-                    </div>
-                    <div class="pull-right upper-right">
-
-						<!--Header Lower-->
-						<div class="header-lower" >
-							<div class="clearfix">
-								<div class="nav-outer clearfix">
-									<!-- Main Menu -->
-									<nav class="main-menu navbar-expand-md">
-										<div class="navbar-header">
-											<!-- Toggle Button -->
-											<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-												<span class="icon-bar"></span>
-												<span class="icon-bar"></span>
-												<span class="icon-bar"></span>
-											</button>
-										</div>
-
-										<div class="navbar-collapse collapse clearfix" id="navbarSupportedContent">
-											<ul class="navigation clearfix">
-												<li class="current"><a href="{% url 'home' %}">{% trans 'Главная' %}</a>
-												</li>
-                                                <li class="dropdown">
-                                                    <a href="#" data-toggle="dropdown" aria-haspopup="true"
-                                                       aria-expanded="false">
-                                                        {% trans 'Контакты' %} <span class="caret"></span>
-                                                    </a>
-                                                    <ul class="dropdown-menu">
-                                                        <li>
-                                                            <a href="{% url 'contacts' %}"
-                                                               class="{% if not selected_country and not selected_city %}active{% endif %}">
-                                                                {% trans 'Все контакты' %}
-                                                            </a>
-                                                        </li>
-                                                        <li class="divider"></li>
-
-                                                        {% for country in countries %}
-                                                        <li class="dropdown">
-                                                            <a href="{% url 'contacts' %}?country={{ country.id }}"
-                                                               class="{% if selected_country == country.id|stringformat:'s' %}active{% endif %}">
-                                                                {{ country.title }} <span class="caret"></span>
-                                                            </a>
-
-                                                            {% with cities_by_country|dict_get:country.id as cities %}
-                                                            {% if cities %}
-                                                            <ul class="dropdown-menu">
-                                                                {% for city in cities %}
-                                                                <li>
-                                                                    <a href="{% url 'contacts' %}?country={{ country.id }}&city={{ city.id }}"
-                                                                       class="{% if selected_city == city.id|stringformat:'s' %}active{% endif %}">
-                                                                        {{ city.title }}
-                                                                    </a>
-                                                                </li>
-                                                                {% endfor %}
-                                                            </ul>
-                                                            {% endif %}
-                                                            {% endwith %}
-                                                        </li>
-                                                        {% endfor %}
-                                                    </ul>
-                                                </li>
-												<li class="dropdown">
-													<a href="#" data-toggle="dropdown"
-													   aria-haspopup="true" aria-expanded="false">
-														{% trans 'Тарифы' %} <span class="caret"></span>
-													</a>
-													<ul class="dropdown-menu">
-														<li><a href="{% url 'rates' %}">{% trans 'Все тарифы' %}</a>
-														</li>
-														<li class="divider"></li>
-														{% for category in rate_categories %}
-														<li>
-															<a href="{% url 'rates_by_category' category.pk %}">
-																{{ category.sender_recipient }}
-															</a>
-														</li>
-														{% endfor %}
-													</ul>
-												</li>
-												<li></li>
-<!--												<li><a href="{% url 'tracking_details' %}">{% trans 'Поиск посылок' %}</a></li>-->
-											</ul>
-										</div>
-                                    </nav>
-
-                                    <!-- Main Menu End-->
-                                    <div class="outer-box clearfix">
-
-                                        <!--Option Box-->
-                                        <div class="option-box">
-
-                                            <!--Search Box-->
-
-
+<div class="page-wrapper">
+    <header class="site-header" role="banner">
+        <div class="top-bar">
+            <div class="top-links">
+                <span class="badge-soft"><i class="fa-solid fa-clock"></i> {% trans 'Мы работаем без выходных' %}</span>
+                <a href="mailto:atlasexpressuz@gmail.com"><i class="fa-regular fa-envelope"></i> atlasexpressuz@gmail.com</a>
+            </div>
+            <div class="top-links">
+                <div class="socials">
+                    <a href="https://www.instagram.com/atlasexpress.usa?igsh=MW9nMGgxYjdqdzV3eA==" target="_blank" rel="noopener" aria-label="Instagram">
+                        <i class="fa-brands fa-instagram"></i>
+                    </a>
+                    <a href="https://www.facebook.com/profile.php?id=61561937198092&mibextid=LQQJ4d" target="_blank" rel="noopener" aria-label="Facebook">
+                        <i class="fa-brands fa-facebook"></i>
+                    </a>
+                    <a href="https://t.me/AtlasExpressUS" target="_blank" rel="noopener" aria-label="Telegram">
+                        <i class="fa-brands fa-telegram"></i>
+                    </a>
+                </div>
+                <a class="muted" href="tel:+998772933300"><i class="fa-solid fa-phone"></i> +998 77 293 33 00</a>
+            </div>
+        </div>
+        <div class="navbar">
+            <a class="logo" href="{% url 'home' %}">
+                <img src="{% static 'images/atlas_logo3.png' %}" alt="Atlas Express">
+                <span>Atlas Express</span>
+            </a>
+            <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation"><i class="fa-solid fa-bars"></i></button>
+            <nav class="nav-links" id="navLinks" role="navigation">
+                <a href="{% url 'home' %}" class="{% if request.path == '/' %}active{% endif %}">{% trans 'Главная' %}</a>
+                <div class="nav-dropdown" data-dropdown>
+                    <button type="button">
+                        {% trans 'Контакты' %}
+                        <i class="fa-solid fa-chevron-down"></i>
+                    </button>
+                    <div class="dropdown-menu-custom">
+                        <a href="{% url 'contacts' %}" class="{% if request.path == '/contacts/' %}active{% endif %}">{% trans 'Все контакты' %}</a>
+                        {% for country in countries %}
+                            <div>
+                                <a href="{% url 'contacts' %}?country={{ country.id }}" class="dropdown-heading">{{ country.title }}</a>
+                                {% with cities_by_country|dict_get:country.id as cities %}
+                                    {% if cities %}
+                                        <div class="stack" style="padding-left: 12px;">
+                                            {% for city in cities %}
+                                                <a href="{% url 'contacts' %}?country={{ country.id }}&city={{ city.id }}" class="muted">{{ city.title }}</a>
+                                            {% endfor %}
                                         </div>
-                                    </div>
+                                    {% endif %}
+                                {% endwith %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="nav-dropdown" data-dropdown>
+                    <button type="button">
+                        {% trans 'Тарифы' %}
+                        <i class="fa-solid fa-chevron-down"></i>
+                    </button>
+                    <div class="dropdown-menu-custom">
+                        <a href="{% url 'rates' %}">{% trans 'Все тарифы' %}</a>
+                        {% for category in rate_categories %}
+                            <a href="{% url 'rates_by_category' category.pk %}">{{ category.sender_recipient }}</a>
+                        {% endfor %}
+                    </div>
+                </div>
+                <a href="{% url 'tracking_details' %}">{% trans 'Отследить' %}</a>
+            </nav>
+            <div class="header-actions">
+                <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+                    <i class="fa-solid fa-moon"></i>
+                </button>
+                <div class="language-switcher">
+                    <button type="button">
+                        <i class="fa-solid fa-globe"></i>
+                        {% if LANGUAGE_CODE == 'en' %}English{% else %}Русский{% endif %}
+                        <i class="fa-solid fa-chevron-down"></i>
+                    </button>
+                    <div class="language-menu">
+                        <form method="post" action="{% url 'set_language' %}">
+                            {% csrf_token %}
+                            <button type="submit" name="language" value="ru" class="{% if LANGUAGE_CODE == 'ru' %}active{% endif %}">Русский</button>
+                            <button type="submit" name="language" value="en" class="{% if LANGUAGE_CODE == 'en' %}active{% endif %}">English</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
 
-                                </div>
+    <main>
+        {% block content %}
+        <section class="hero" id="hero">
+            <div class="container">
+                <div class="hero-content">
+                    <span class="chip">{% trans 'Международная доставка' %}</span>
+                    <h1>{% trans 'Доставляем посылки быстро и безопасно' %}</h1>
+                    <p>{% trans 'Atlas Express соединяет США и Узбекистан, обеспечивая прозрачный контроль каждой посылки и сервис класса Premium.' %}</p>
+                    <div class="hero-actions">
+                        <a class="btn btn-primary" href="{% url 'rates' %}"><i class="fa-solid fa-plane-departure"></i> {% trans 'Посмотреть тарифы' %}</a>
+                        <a class="btn btn-outline" href="{% url 'contacts' %}"><i class="fa-solid fa-comments"></i> {% trans 'Связаться с нами' %}</a>
+                    </div>
+                    <div class="hero-stats">
+                        <div class="stat-card">
+                            <span class="chip"><i class="fa-solid fa-globe"></i> {% trans 'География' %}</span>
+                            <div>
+                                <strong>{{ countries|length|default:0 }} {% trans 'страны присутствия' %}</strong>
+                                <div>{% trans 'Представительства и пункты выдачи в США и Узбекистане' %}</div>
                             </div>
                         </div>
-						<!--End Header Lower-->
-
+                        <div class="stat-card">
+                            <span class="chip"><i class="fa-solid fa-shield-heart"></i> {% trans 'Контроль' %}</span>
+                            <div>
+                                <strong>{% trans '24/7 мониторинг отправлений' %}</strong>
+                                <div>{% trans 'Актуальный статус посылок в личном кабинете и по номеру трека' %}</div>
+                            </div>
+                        </div>
                     </div>
-
                 </div>
-
+                <div class="hero-card">
+                    <h3>{% trans 'Отследить посылку' %}</h3>
+                    <form method="post" action="{% url 'track_package' %}" class="track-form">
+                        {% csrf_token %}
+                        <div class="input-group">
+                            <input type="text" name="trackid" placeholder="{% trans 'Введите ID посылки' %}" required>
+                        </div>
+                        <button class="btn btn-primary" type="submit"><i class="fa-solid fa-magnifying-glass"></i> {% trans 'Проверить статус' %}</button>
+                        <span class="helper-text"><i class="fa-regular fa-lightbulb"></i> {% trans 'Мы покажем последние обновления и примерную дату доставки.' %}</span>
+                    </form>
+                </div>
             </div>
-        </div>
-        <!--End Header Upper-->
+        </section>
 
-		<!--Sticky Header-->
-        <div class="sticky-header">
-        	<div class="auto-container clearfix">
-            	<!--Logo-->
-            	<div class="logo pull-left">
-                	<a href="{% url 'home' %}" class="img-responsive"><img src="{% static 'images/atlas_logo3.png' %}" alt="" title=""></a>
+        <section class="section" id="services">
+            <div class="container">
+                <div class="section-header">
+                    <span class="chip"><i class="fa-solid fa-star"></i> {% trans 'Почему Atlas Express' %}</span>
+                    <h2>{% trans 'Сервис, созданный для вашего комфорта' %}</h2>
+                    <p>{% trans 'Комплексное сопровождение от оформления заказа до доставки в пункт выдачи. Никаких скрытых платежей и максимум заботы.' %}</p>
                 </div>
+                <div class="feature-grid">
+                    <article class="feature-card">
+                        <div class="feature-icon"><i class="fa-solid fa-gauge-high"></i></div>
+                        <h3>{% trans 'Скорость и точность' %}</h3>
+                        <p>{% trans 'Оптимизированная логистика и цифровые инструменты позволяют доставлять заказы точно в срок.' %}</p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon"><i class="fa-solid fa-box-open"></i></div>
+                        <h3>{% trans 'Надёжная упаковка' %}</h3>
+                        <p>{% trans 'Каждая посылка проходит контроль и дополнительную защиту, чтобы доехать в идеальном состоянии.' %}</p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon"><i class="fa-solid fa-headset"></i></div>
+                        <h3>{% trans 'Персональная поддержка' %}</h3>
+                        <p>{% trans 'Команда саппорта отвечает на вопросы в мессенджерах и помогает на каждом этапе пути.' %}</p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon"><i class="fa-solid fa-shield-halved"></i></div>
+                        <h3>{% trans 'Прозрачность и безопасность' %}</h3>
+                        <p>{% trans 'Мы работаем официально, предоставляя страховку и прозрачные отчёты по каждой доставке.' %}</p>
+                    </article>
+                </div>
+            </div>
+        </section>
 
-                <!--Right Col-->
-                <div class="right-col pull-right">
-                	<!-- Main Menu -->
-                    <nav class="main-menu navbar-expand-md">
-                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent1" aria-controls="navbarSupportedContent1" aria-expanded="false" aria-label="Toggle navigation">
-                            <span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-
-						<div class="navbar-collapse collapse clearfix" id="navbarSupportedContent1">
-							<ul class="navigation clearfix">
-								<li class="current"><a href="{% url 'home' %}">{% trans 'Главная' %}<i
-										class="fa fa-angle-down"></i></a>
-								</li>
-								<li class="dropdown">
-									<a href="{% url 'contacts' %}">{% trans 'Контакты' %}</a>
-									<ul>
-										<li>
-											<a href="{% url 'contacts' %}"
-											   class="{% if not selected_country and not selected_city %}active{% endif %}">
-												{% trans 'Все контакты' %}
-											</a>
-										</li>
-
-										{% for country in countries %}
-										<li class="dropdown">
-											<a href="{% url 'contacts' %}?country={{ country.id }}"
-											   class="{% if selected_country == country.id|stringformat:'s' %}active{% endif %}">
-												{{ country.title }}
-															</a>
-
-                                            {% with cities_by_country|dict_get:country.id as cities %}
-                                            {% if cities %}
-                                            <ul>
-                                                {% for city in cities %}
-                                                <li>
-                                                    <a href="{% url 'contacts' %}?country={{ country.id }}&city={{ city.id }}"
-                                                       class="{% if selected_city == city.id|stringformat:'s' %}active{% endif %}">
-                                                        {{ city.title }}
-                                                    </a>
-                                                </li>
-                                                {% endfor %}
-                                            </ul>
-                                            {% endif %}
-                                            {% endwith %}
-                                            <div class="dropdown-btn"><span
-                                                    class="fa fa-angle-down"></span></div>
-                                        </li>
-                                        {% endfor %}
-                                    </ul>
-                                    <div class="dropdown-btn"><span class="fa fa-angle-down"></span>
+        <section class="section rates-section" id="rates">
+            <div class="container">
+                <div class="section-header">
+                    <span class="chip"><i class="fa-solid fa-scale-balanced"></i> {% trans 'Актуальные тарифы' %}</span>
+                    <h2>{% trans 'Выберите подходящее предложение' %}</h2>
+                    <p>{% trans 'Выгодные условия для личных и корпоративных отправлений. Лучшие цены на доставку из США.' %}</p>
+                </div>
+                {% if rates %}
+                    <div class="rates-grid">
+                        {% for rate in rates %}
+                            <article class="rate-card {% if rate.is_hot %}hot{% endif %}">
+                                {% if rate.is_hot %}
+                                    <span class="badge">🔥 {% trans 'Популярный тариф' %}</span>
+                                {% else %}
+                                    <span class="badge">{{ rate.country }}</span>
+                                {% endif %}
+                                <div>
+                                    <div class="price-tag">{{ rate.price }}$ <span>/{% trans 'кг' %}</span></div>
+                                    <div class="rate-meta">
+                                        <span>📦 {{ rate.rate_title }}</span>
+                                        <span>⏱ {% trans 'Доставка:' %} {{ rate.delivery_within }} {% trans 'дней' %}</span>
+                                        <span>⚖️ {% trans 'Минимальный вес:' %} {{ rate.minimal_weight }} {% trans 'кг' %}</span>
                                     </div>
-                                </li>
-								<li class="dropdown">
-									<a href="#" data-toggle="dropdown"
-									   aria-haspopup="true" aria-expanded="false">
-									{% trans 'Тарифы' %} <span class="caret"></span>
-									</a>
-									<ul class="dropdown-menu">
-										<li><a href="{% url 'rates' %}">{% trans 'Все тарифы' %}</a></li>
-										<li class="divider"></li>
-										{% for category in rate_categories %}
-										<li>
-											<a href="{% url 'rates_by_category' category.pk %}">
-												{{ category.sender_recipient }}
-											</a>
-										</li>
-										{% endfor %}
-									</ul>
-								</li>
-								<li><a href="{% url 'tracking_details' %}">{% trans 'Поиск посылок' %}</a></li>
-							</ul>
-                        </div>
-                    </nav><!-- Main Menu End-->
+                                </div>
+                                <a class="btn btn-outline" href="{% url 'rates' %}"><i class="fa-solid fa-arrow-up-right-from-square"></i> {% trans 'Смотреть все тарифы' %}</a>
+                            </article>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="text-center muted">{% trans 'Тарифы временно недоступны, свяжитесь с менеджером для уточнения.' %}</div>
+                {% endif %}
+            </div>
+        </section>
 
+        <section class="section journey-section" id="journey">
+            <div class="container">
+                <div class="section-header">
+                    <span class="chip"><i class="fa-solid fa-route"></i> {% trans 'Как это работает' %}</span>
+                    <h2>{% trans 'Путь вашей посылки' %}</h2>
+                    <p>{% trans 'Мы делаем международную доставку простой: от приёма в США до вручения в Узбекистане всего несколько шагов.' %}</p>
                 </div>
-
-            </div>
-        </div>
-        <!--End Sticky Header-->
-
-    </header>
-    <!--End Main Header -->
-
-	<!--Banner Section-->
-    {{ banner_section|safe }}
-	<!--End Banner Section-->
-
-	<!-- About Section -->
-<!--	<section class="about-section blue">-->
-<!--		<div class="auto-container">-->
-<!--			<div class="sec-title blue centered">-->
-<!--				<h3>About <span>The Carga</span></h3>-->
-<!--				<div class="separater"></div>-->
-<!--				<div class="text">With over 50 years experience in the Cargo and Transport Services</div>-->
-<!--			</div>-->
-<!--			-->
-<!--			<div class="row clearfix">-->
-<!--				-->
-<!--				&lt;!&ndash; Video Column &ndash;&gt;-->
-<!--				<div class="video-column col-lg-6 col-md-12 col-sm-12">-->
-<!--					<div class="inner-column wow fadeInLeft" data-wow-delay="0ms" data-wow-duration="1500ms">-->
-<!--						-->
-<!--						&lt;!&ndash;Video Box&ndash;&gt;-->
-<!--						<div class="video-box">-->
-<!--							<figure class="image">-->
-<!--								<img src="images/resource/video-image.jpg" alt="">-->
-<!--							</figure>-->
-<!--							<a href="https://www.youtube.com/watch?v=kxPCFljwJws" class="lightbox-image overlay-box"><i class="play-now flaticon-play-button-4"></i></a>-->
-<!--						</div>-->
-<!--						-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--				&lt;!&ndash; Content Column &ndash;&gt;-->
-<!--				<div class="content-column col-lg-6 col-md-12 col-sm-12">-->
-<!--					<div class="inner-column wow fadeInRight" data-wow-delay="0ms" data-wow-duration="1500ms">-->
-<!--						<h3>Reach your destination 100% sure and safe</h3>-->
-<!--						<div class="text">-->
-<!--							<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia, quis nostrud exercitation ullamco laboris  .</p>-->
-<!--							<blockquote>-->
-<!--								Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia, quis nostrud exercitation ullamco laboris .-->
-<!--							</blockquote>-->
-<!--							<p>ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>-->
-<!--						</div>-->
-<!--						<a href="#" class="theme-btn btn-style-one">Read More</a>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--			</div>-->
-<!--			-->
-<!--			<div class="row clearfix">-->
-<!--				-->
-<!--				&lt;!&ndash; Services Block &ndash;&gt;-->
-<!--				<div class="services-block col-lg-4 col-md-6 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInLeft" data-wow-delay="0ms" data-wow-duration="1500ms">-->
-<!--						<div class="icon-box">-->
-<!--							<span class="icon flaticon-calendar-1"></span>-->
-<!--						</div>-->
-<!--						<h2><a href="#">80% Time Speed</a></h2>-->
-<!--						<div class="category">Design Packages</div>-->
-<!--						<div class="text">Benenatis mauris. Vestibulum ante ipsum primis in industry, logistics,nance, business orci ultrices.</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--				&lt;!&ndash; Services Block &ndash;&gt;-->
-<!--				<div class="services-block col-lg-4 col-md-6 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInLeft" data-wow-delay="300ms" data-wow-duration="1500ms">-->
-<!--						<div class="icon-box">-->
-<!--							<span class="icon flaticon-gps"></span>-->
-<!--						</div>-->
-<!--						<h2><a href="#">Track All Your Shippings</a></h2>-->
-<!--						<div class="category">Flexible Movers</div>-->
-<!--						<div class="text">Benenatis mauris. Vestibulum ante ipsum primis in industry, logistics,nance, business orci ultrices.</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--				&lt;!&ndash; Services Block &ndash;&gt;-->
-<!--				<div class="services-block col-lg-4 col-md-6 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInLeft" data-wow-delay="600ms" data-wow-duration="1500ms">-->
-<!--						<div class="icon-box">-->
-<!--							<span class="icon flaticon-help-operator"></span>-->
-<!--						</div>-->
-<!--						<h2><a href="#">24/7 Support</a></h2>-->
-<!--						<div class="category">Regular Visits</div>-->
-<!--						<div class="text">Benenatis mauris. Vestibulum ante ipsum primis in industry, logistics,nance, business orci ultrices.</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--			</div>-->
-<!--			-->
-<!--		</div>-->
-<!--	</section>-->
-	<!-- End About Section -->
-
-	<!-- Services Section -->
-	<section class="services-section" style=" background-image:url({% static 'images/background/2.png' %} )">
-		<div class="auto-container">
-			{% block content %}
-			{% if rates %}
-    <div class="sec-title blue centered">
-      <h3><span>{% trans 'Тарифы' %}</span></h3>
-      <div class="separater"></div>
-    </div>
-
-    <div class="row clearfix">
-      {% for rate in rates %}
-        {% if forloop.counter == 2 %}
-          {# второй из трёх — «красивый» стиль #}
-          <div class="price-block style-two active col-lg-4 col-md-6 col-sm-12">
-            <div class="inner-box wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
-              <div class="title">{{ rate.country }}</div>
-              <div class="price-box">
-                <div class="price">{{ rate.price }}$</div>
-                <div class="months">/{% trans 'КГ' %}</div>
-              </div>
-              <ul class="price-list">
-				  <li>{{ rate.rate_title }}</li>
-                <li>{% trans 'Доставка в течение:' %} {{ rate.delivery_within }} {% trans 'дней' %}</li>
-                <li>{% trans 'Минимальный вес:' %} {{ rate.minimal_weight }} {% trans 'кг' %}</li>
-              </ul>
-				<br>
-				<br>
-              <div class="btn-box">
-                <a href="{% url 'rates' %}" class="theme-btn choose-btn">{% trans 'Подробно' %}</a>
-              </div>
-            </div>
-          </div>
-        {% else %}
-          {# первый и третий — стандартный блок #}
-          <div class="price-block col-lg-4 col-md-6 col-sm-12">
-            <div class="inner-box wowallow fadeInLeft animated"
-                 data-wow-delay="0ms" data-wow-duration="1500ms">
-				<div class="title">{{ rate.country }}</div>
-              <div class="price-box">
-                <div class="price">{{ rate.price }}$</div>
-                <div class="months">/{% trans 'КГ' %}</div>
-              </div>
-              <ul class="price-list">
-                <li>{{ rate.rate_title }}</li>
-                <li>{% trans 'Доставка в течение:' %} {{ rate.delivery_within }} {% trans 'дней' %}</li>
-                <li>{% trans 'Минимальный вес:' %} {{ rate.minimal_weight }} {% trans 'кг' %}</li>
-              </ul>
-              <div class="btn-box">
-                <a href="{% url 'rates' %}" class="theme-btn choose-btn">{% trans 'Подробно' %}</a>
-              </div>
-            </div>
-          </div>
-        {% endif %}
-      {% endfor %}
-    </div>
-  {% else %}
-    <p>Тарифов пока нет.</p>
-  {% endif %}
-			{% endblock %}
-		</div>
-	</section>
-	<!-- End Services Section -->
-
-	<!-- News Section -->
-<!--	<section class="news-section">-->
-<!--		<div class="auto-container">-->
-<!--			<div class="sec-title blue centered">-->
-<!--				<h3>Latest <span>Blog Posts</span></h3>-->
-<!--				<div class="separater"></div>-->
-<!--				<div class="text">With over 50 years experience in the Cargo and Transport Services</div>-->
-<!--			</div>-->
-<!--			-->
-<!--			<div class="row clearfix">-->
-<!--			-->
-<!--				&lt;!&ndash; News Block &ndash;&gt;-->
-<!--				<div class="news-block col-lg-6 col-md-12 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">-->
-<!--						<div class="row clearfix">-->
-<!--							&lt;!&ndash; Image Column &ndash;&gt;-->
-<!--							<div class="image-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<div class="image">-->
-<!--										<a href="#"><img src="images/resource/news-1.jpg" alt="" /></a>-->
-<!--									</div>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--							&lt;!&ndash; Content Column &ndash;&gt;-->
-<!--							<div class="content-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<ul class="post-meta">-->
-<!--										<li><span class="icon flaticon-calendar-1"></span>Oct 18 ,2018</li>-->
-<!--										<li><span class="icon fa fa-user"></span>Allan Doe</li>-->
-<!--									</ul>-->
-<!--									<h3><a href="#">Cargo Ships Arrival</a></h3>-->
-<!--									<div class="text">Lorem ipsum dolor sit amectetur adipisic ing elit, sed do eiusmod  didunt ut labore .</div>-->
-<!--									<a href="#" class="read-more">Read more</a>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--						</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--				&lt;!&ndash; News Block &ndash;&gt;-->
-<!--				<div class="news-block col-lg-6 col-md-12 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInUp" data-wow-delay="300ms" data-wow-duration="1500ms">-->
-<!--						<div class="row clearfix">-->
-<!--							&lt;!&ndash; Image Column &ndash;&gt;-->
-<!--							<div class="image-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<div class="image">-->
-<!--										<a href="#"><img src="images/resource/news-2.jpg" alt="" /></a>-->
-<!--									</div>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--							&lt;!&ndash; Content Column &ndash;&gt;-->
-<!--							<div class="content-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<ul class="post-meta">-->
-<!--										<li><span class="icon flaticon-calendar-1"></span>Dec 09 ,2018</li>-->
-<!--										<li><span class="icon fa fa-user"></span>Allan Doe</li>-->
-<!--									</ul>-->
-<!--									<h3><a href="#">How Shipments Works?</a></h3>-->
-<!--									<div class="text">Lorem ipsum dolor sit amectetur adipisic ing elit, sed do eiusmod  didunt ut labore .</div>-->
-<!--									<a href="#" class="read-more">Read more</a>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--						</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--				&lt;!&ndash; News Block &ndash;&gt;-->
-<!--				<div class="news-block col-lg-6 col-md-12 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInUp" data-wow-delay="600ms" data-wow-duration="1500ms">-->
-<!--						<div class="row clearfix">-->
-<!--							&lt;!&ndash; Image Column &ndash;&gt;-->
-<!--							<div class="image-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<div class="image">-->
-<!--										<a href="#"><img src="images/resource/news-3.jpg" alt="" /></a>-->
-<!--									</div>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--							&lt;!&ndash; Content Column &ndash;&gt;-->
-<!--							<div class="content-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<ul class="post-meta">-->
-<!--										<li><span class="icon flaticon-calendar-1"></span>Dec 27 ,2018</li>-->
-<!--										<li><span class="icon fa fa-user"></span>Allan Doe</li>-->
-<!--									</ul>-->
-<!--									<h3><a href="#">Here, Time Matters</a></h3>-->
-<!--									<div class="text">Lorem ipsum dolor sit amectetur adipisic ing elit, sed do eiusmod  didunt ut labore .</div>-->
-<!--									<a href="#" class="read-more">Read more</a>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--						</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--				&lt;!&ndash; News Block &ndash;&gt;-->
-<!--				<div class="news-block col-lg-6 col-md-12 col-sm-12">-->
-<!--					<div class="inner-box wow fadeInUp" data-wow-delay="900ms" data-wow-duration="1500ms">-->
-<!--						<div class="row clearfix">-->
-<!--							&lt;!&ndash; Image Column &ndash;&gt;-->
-<!--							<div class="image-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<div class="image">-->
-<!--										<a href="#"><img src="images/resource/news-4.jpg" alt="" /></a>-->
-<!--									</div>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--							&lt;!&ndash; Content Column &ndash;&gt;-->
-<!--							<div class="content-column col-lg-6 col-md-6 col-sm-12">-->
-<!--								<div class="inner-column">-->
-<!--									<ul class="post-meta">-->
-<!--										<li><span class="icon flaticon-calendar-1"></span>Jan 19 ,2020</li>-->
-<!--										<li><span class="icon fa fa-user"></span>Allan Doe</li>-->
-<!--									</ul>-->
-<!--									<h3><a href="#">Air Frieght Landed.</a></h3>-->
-<!--									<div class="text">Lorem ipsum dolor sit amectetur adipisic ing elit, sed do eiusmod  didunt ut labore .</div>-->
-<!--									<a href="#" class="read-more">Read more</a>-->
-<!--								</div>-->
-<!--							</div>-->
-<!--						</div>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--			-->
-<!--			</div>-->
-<!--		</div>	-->
-<!--	</section>-->
-	<!-- End News Section -->
-
-	<!-- Counter Section -->
-	{% block counter_section %}
-	<section class="counter-section" style="background-image:url(images/background/3.jpg)">
-		<div class="auto-container">
-			<div class="row clearfix">
-
-				<!-- Order Column -->
-				<div class="order-column col-lg-6 col-md-12 col-sm-12">
-					<div class="inner-column blue" style="background-image:url({% static 'images/background/4.png' %})">
-						<div class="icon-box">
-
-						</div>
-						<h2>{% trans 'Поиск посылок' %}</h2>
-						<div class="text">{% trans 'Введите ID посылки' %}</div>
-
-
-
-<!--						<form method="post"-->
-<!--      action="{% url 'track_package' %}"-->
-<!--      class="track-form">-->
-<!--  {% csrf_token %}-->
-<!--  <div class="form-group">-->
-<!--    <input type="text" name="trackid"-->
-<!--           placeholder="Введите ID посылки" required>-->
-<!--  </div>-->
-<!--  <div class="form-group">-->
-<!--    <button type="submit" class="theme-btn btn-style-one">-->
-<!--      Поиск-->
-<!--    </button>-->
-<!--  </div>-->
-<!--</form>-->
-
-
-
-
-						<!--Track Form-->
-						<div class="track-form">
-							<form method="post"
-								  action="{% url 'track_package' %}" {# или ваш URL для обработки POST #}
-								  class="track-form">
-								{% csrf_token %}
-								<div class="form-group">
-									<input type="text"
-										   name="trackid"
-										   placeholder="ID"
-										   required>
-									<button type="submit" class="theme-btn">
-										<span class="fa fa-search"></span>
-									</button>
-								</div>
-							</form>
+                <div class="timeline">
+                    <div class="timeline-step active">
+                        <div class="dot">1</div>
+                        <div>
+                            <h4>{% trans 'Приём и проверка' %}</h4>
+                            <p>{% trans 'Забираем посылку в США, проверяем содержимое и подготавливаем документы.' %}</p>
                         </div>
+                    </div>
+                    <div class="timeline-step active">
+                        <div class="dot">2</div>
+                        <div>
+                            <h4>{% trans 'Консолидация и отправка' %}</h4>
+                            <p>{% trans 'Объединяем грузы, страхуем и отправляем на рейсе в Узбекистан.' %}</p>
+                        </div>
+                    </div>
+                    <div class="timeline-step">
+                        <div class="dot">3</div>
+                        <div>
+                            <h4>{% trans 'Таможенное оформление' %}</h4>
+                            <p>{% trans 'Работаем напрямую с таможенными органами, чтобы ускорить прохождение контроля.' %}</p>
+                        </div>
+                    </div>
+                    <div class="timeline-step">
+                        <div class="dot">4</div>
+                        <div>
+                            <h4>{% trans 'Выдача или доставка' %}</h4>
+                            <p>{% trans 'Передаём в пункт выдачи или организуем адресную доставку в вашем городе.' %}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
 
-						<!-- Social Box -->
-						<div class="social-box">
-							<a href="#" class="fa-brands fa-twitter"></a>
-							<a href="#" class="fa-brands fa-facebook"></a>
-							<a href="#" class="fa-brands fa-linkedin"></a>
-							<a href="#" class="fa-brands fa-google-plus"></a>
-						</div>
+        <section class="section addresses-section" id="network">
+            <div class="container">
+                <div class="section-header">
+                    <span class="chip"><i class="fa-solid fa-map-location-dot"></i> {% trans 'Наша сеть' %}</span>
+                    <h2>{% trans 'Адреса представительств и складов' %}</h2>
+                    <p>{% trans 'Выбирайте удобный пункт выдачи для получения посылки. Мы расширяем сеть и добавляем новые локации.' %}</p>
+                </div>
+                <div class="address-grid">
+                    {% for address in addresses %}
+                        <article class="address-card">
+                            {% if address.city and address.city.country %}
+                                <span class="badge-soft">{{ address.city.country.title }}</span>
+                            {% endif %}
+                            <h4>{{ address.title }}</h4>
+                            {% if address.city %}
+                                <span><i class="fa-solid fa-location-dot"></i> {{ address.city }}</span>
+                            {% endif %}
+                            {% if address.phone %}
+                                <span><i class="fa-solid fa-phone"></i> {{ address.phone }}</span>
+                            {% endif %}
+                            {% if address.coordinates1 %}
+                                <a class="btn btn-outline" href="https://www.google.com/maps?q={{ address.coordinates1 }}" target="_blank" rel="noopener">
+                                    <i class="fa-solid fa-map"></i> {% trans 'Открыть в Google Maps' %}
+                                </a>
+                            {% endif %}
+                        </article>
+                    {% empty %}
+                        <div class="muted">{% trans 'Контакты временно недоступны.' %}</div>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
 
-					</div>
-				</div>
+        <section class="cta-section" id="cta">
+            <div class="container">
+                <div class="cta-card">
+                    <h2>{% trans 'Готовы отправить посылку?' %}</h2>
+                    <p>{% trans 'Оставьте заявку и мы подберём оптимальный способ доставки, рассчитаем стоимость и сопроводим до вручения.' %}</p>
+                    <a class="btn btn-primary" href="{% url 'contacts' %}"><i class="fa-solid fa-paper-plane"></i> {% trans 'Связаться с менеджером' %}</a>
+                </div>
+            </div>
+        </section>
+        {% endblock %}
+    </main>
 
-				<!-- Counter Column -->
-				<div class="counter-column col-lg-6 col-md-12 col-sm-12">
-					<div class="inner-column">
-
-						<div class="fact-counter">
-							<div class="clearfix">
-								<!--Column-->
-								<div class="column counter-column col-lg-6 col-md-6 col-sm-12">
-									<div class="inner blue">
-										<div class="content">
-											<div class="count-outer count-box">
-												<span class="count-text" data-speed="2000" data-stop="8">0</span>
-											</div>
-											<h4 class="counter-title">{% trans 'Многолетний опыт' %}</h4>
-										</div>
-									</div>
-								</div>
-
-								<!--Column-->
-								<div class="column counter-column col-lg-6 col-md-6 col-sm-12">
-									<div class="inner blue">
-										<div class="content">
-											<div class="count-outer count-box alternate">
-												<span class="count-text" data-speed="2800" data-stop="258">0</span>+
-											</div>
-											<h4 class="counter-title">{% trans 'Профессиональные сотрудники' %}</h4>
-										</div>
-									</div>
-								</div>
-
-								<!--Column-->
-								<div class="column counter-column col-lg-6 col-md-6 col-sm-12">
-									<div class="inner blue">
-										<div class="content">
-											<div class="count-outer count-box">
-												<span class="count-text" data-speed="2500" data-stop="50">0</span>%
-											</div>
-											<h4 class="counter-title">{% trans 'Охваченные территории' %}</h4>
-										</div>
-									</div>
-								</div>
-
-								<!--Column-->
-
-								<!--Column-->
-								<div class="column counter-column col-lg-6 col-md-6 col-sm-12">
-									<div class="inner blue">
-										<div class="content">
-											<div class="count-outer count-box">
-												<span class="count-text" data-speed="2000" data-stop="70000">0</span>+
-											</div>
-											<h4 class="counter-title">{% trans 'Корпоративные клиенты' %}</h4>
-										</div>
-									</div>
-								</div>
-
-								<!--Column-->
-
-							</div>
-						</div>
-
-
-					</div>
-				</div>
-
-			</div>
-		</div>
-	</section>
-	{% endblock %}
-	<!-- Testimonial Section -->
-	{% if addresses %}
-	<section class="testimonial-section">
-		<div class="auto-container">
-			<div class="sec-title centered">
-				<h3>{% trans 'Контакты' %}</h3>
-				<div class="separater"></div>
-			</div>
-			<div class="two-item-carousel owl-carousel owl-theme">
-
-				<!-- Testimonial Block -->
-				{% for address in addresses %}
-				<div class="testimonial-block blue">
-					<div class="inner-box">
-						<div class="quote-icon flaticon-left-quote"></div>
-						<div class="embed-responsive embed-responsive-16by9">
-							<iframe
-									class="embed-responsive-item"
-									src="https://www.google.com/maps?q={{ address.coordinates1 }}&hl=ru&z=14&output=embed"
-									allowfullscreen
-									loading="lazy"
-									style="border:0;">
-							</iframe>
-						</div>
-						<div class="author-info">
-							<div class="info-inner">
-									{% if address.city and address.city.country and address.city.country.photo %}
-									<div class="author-image">
-										<img src="{{ address.city.country.photo.url }}" alt=""/>
-									</div>
-									{% endif %}
-								<h4>{{ address.country }}</h4>
-								<div class="designation">{{ address.title }}</div>
-								<div class="designation">{{ address.city }}</div>
-								<!-- Social Box -->
-								<div class="designation">📞 {{ address.phone }}</div>
-
-							</div>
-						</div>
-						<br>
-					</div>
-				</div>
-				{% endfor %}
-				<!-- Testimonial Block -->
-
-			</div>
-		</div>
-	</section>
-	<!-- End Testimonial Section -->
-	{% endif %}
-	<!--Sponsors Section-->
-	<section class="sponsors-section">
-		<div class="auto-container">
-
-		</div>
-	</section>
-	<!--End Sponsors Section-->
-
-
-
-	<!-- Fullwidth Section -->
-<!--	<section class="fullwidth-section blue">-->
-<!--		<div class="outer-container">-->
-<!--			<div class="clearfix">-->
-<!--				-->
-<!--				&lt;!&ndash; Left Column &ndash;&gt;-->
-<!--				-->
-<!--				&lt;!&ndash; Right Column &ndash;&gt;-->
-<!--				<div class="right-column" style="background-image:url({% static 'images/background/6.jpg' %})">-->
-<!--					<div class="inner-column">-->
-<!--						<h3>Are You A Shipper?</h3>-->
-<!--						<div class="text">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore.</div>-->
-<!--						<a href="#" class="theme-btn btn-style-two">Contact us</a>-->
-<!--					</div>-->
-<!--				</div>-->
-<!--				-->
-<!--			</div>-->
-<!--		</div>-->
-<!--	</section>-->
-	<!-- End Fullwidth Section -->
-<!--<button id="theme-toggle" class="theme-btn">Тёмная тема</button>-->
-	<!--Main Footer-->
-    <footer class="main-footer blue" style="background-image:url({% static 'images/background/7.png' %})">
-    	<div class="auto-container">
-  <!--Widgets Section-->
-  <div class="widgets-section">
-    <div class="row justify-content-center">
-
-      <!-- Useful Links -->
-      <div class="col-lg-4 col-md-6 col-sm-12 text-center mb-4">
-        <div class="footer-widget logo-widget">
-          <h2 style="color: #fff"><span class="icon fa fa-thumbs-o-up"></span>{% trans 'Ссылки на сайт' %}</h2>
-          <ul class="footer-list list-unstyled">
-		    <li><a href="#">{% trans 'Главная' %}</a></li>
-            <li><a href="#">{% trans 'Поиск посылок' %}</a></li>
-            <li><a href="#">{% trans 'Тарифы' %}</a></li>
-            <li><a href="#">{% trans 'Контакты' %}</a></li>
-            <li><a href="#">{% trans 'Связатся с нами' %}</a></li>
-          </ul>
+    <footer class="site-footer">
+        <div class="footer-grid">
+            <div>
+                <a class="logo" href="{% url 'home' %}">
+                    <img src="{% static 'images/atlas_logo3.png' %}" alt="Atlas Express">
+                    <span>Atlas Express</span>
+                </a>
+                <p class="muted">{% trans 'Atlas Express — современный сервис международной доставки с фокусом на скорость, безопасность и заботу о клиентах.' %}</p>
+            </div>
+            <div>
+                <h4>{% trans 'Навигация' %}</h4>
+                <ul>
+                    <li><a href="{% url 'home' %}">{% trans 'Главная' %}</a></li>
+                    <li><a href="{% url 'rates' %}">{% trans 'Тарифы' %}</a></li>
+                    <li><a href="{% url 'contacts' %}">{% trans 'Контакты' %}</a></li>
+                    <li><a href="{% url 'tracking_details' %}">{% trans 'Отследить посылку' %}</a></li>
+                </ul>
+            </div>
+            <div>
+                <h4>{% trans 'Связаться' %}</h4>
+                <ul>
+                    <li><a href="mailto:atlasexpressuz@gmail.com"><i class="fa-regular fa-envelope"></i> atlasexpressuz@gmail.com</a></li>
+                    <li><a href="tel:+998772933300"><i class="fa-solid fa-phone"></i> +998 77 293 33 00</a></li>
+                    <li><a href="https://t.me/AtlasExpressUS" target="_blank" rel="noopener"><i class="fa-brands fa-telegram"></i> Telegram</a></li>
+                </ul>
+            </div>
         </div>
-      </div>
-
-      <!-- Recent News -->
-      <div class="col-lg-4 col-md-6 col-sm-12 text-center mb-4">
-        <div class="footer-widget news-widget">
-          <h2 style="color: #fff"><span class="icon fa fa-bullhorn"></span>{% trans 'Последние новости' %}</h2>
-          <div class="news-widget-block">
-            <h4><a href="#">{% trans 'Добавлены новые регулярные рейсы в Канаду' %}</a></h4>
-            <div class="post-date">{% trans 'Авг 15, 2024' %}</div>
-          </div>
-          <div class="news-widget-block">
-            <h4><a href="#">{% trans 'Представлен сайт который можно следить посылок' %}</a></h4>
-            <div class="post-date">{% trans 'Сен 26, 2024' %}</div>
-          </div>
-          <div class="news-widget-block">
-            <h4><a href="#">{% trans 'Запущена услуга карбон-нейтральной доставки' %}</a></h4>
-            <div class="post-date">{% trans 'Ноя 20, 2024' %}</div>
-          </div>
+        <div class="footer-bottom">
+            <span>© {% now "Y" %} Atlas Express</span>
+            <span class="muted">{% trans 'Все права защищены' %}</span>
         </div>
-      </div>
+    </footer>
+</div>
 
-      <!-- О нас -->
-      <div class="col-lg-4 col-md-6 col-sm-12 text-center mb-4">
-        <div class="footer-widget about-widget">
-          <h2 style="color: #fff"><span class="icon fa fa-user"></span>{% trans 'О нас' %}</h2>
-          <p>{% trans 'Atlas Express — это ваш надёжный партнёр в сфере экспресс-доставки по всему миру. Мы совмещаем высокие стандарты качества и индивидуальный подход к каждому клиенту, чтобы ваши отправления доходили в срок и в полной сохранности.' %}</p>
-          <p class="mb-1"><a href="tel:+998772933300">+998 77 293 33 00</a></p>
-			 <p class="mb-1"><a href="tel:+13477933300">+1 347 793 33 00</a></p>
-          <p><a href="mailto:atlas_express@gmail.com">atlasexpressuz@gmail.com</a></p>
-          <ul class="list-inline mt-3">
-            <li class="list-inline-item"><a href="https://www.instagram.com/atlasexpress.usa?igsh=MW9nMGgxYjdqdzV3eA=="><span class="fa-brands fa-instagram"></span></a></li>
-            <li class="list-inline-item"><a href="https://www.facebook.com/profile.php?id=61561937198092&mibextid=LQQJ4d"><span class="fa-brands fa-facebook"></span></a></li>
-            <li class="list-inline-item"><a href="https://t.me/AtlasExpressUS"><span class="fa-brands fa-telegram"></span></a></li>
-          </ul>
+<div class="modal fade" id="resultModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content my-modal-content">
+            <div class="modal-header my-modal-header">
+                <h5 class="modal-title"><i class="fa-solid fa-box"></i> {% trans 'Статус посылки' %}</h5>
+                <button type="button" class="close my-modal-close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body my-modal-body" id="modalBody"></div>
+            <div class="modal-footer my-modal-footer" id="modalFooter"></div>
         </div>
-      </div>
-
     </div>
-  </div>
 </div>
-
-		<!-- Footer Bottom -->
-		<div class="footer-bottom" style="background-color: #0077ab">
-			<div class="copyright">Atlas Express © {% now "Y" %} / {% trans 'Все права защищены' %}</div>
-		</div>
-
-	</footer>
-
-</div>
-<!--End pagewrapper-->
-
-<!--Scroll to top-->
-<div class="scroll-to-top scroll-to-target" data-target="html"><span class="fa fa-arrow-up"></span></div>
 
 <script src="{% static 'js/jquery-3.5.1.min.js' %}"></script>
 <script src="{% static 'js/popper.min.js' %}"></script>
 <script src="{% static 'js/bootstrap.min.js' %}"></script>
-<script src="{% static 'js/jquery.mCustomScrollbar.concat.min.js' %}"></script>
-<script src="{% static 'js/jquery.fancybox.js' %}"></script>
-<script src="{% static 'js/appear.js' %}"></script>
-<script src="{% static 'js/owl.js' %}"></script>
-<script src="{% static 'js/wow.js' %}"></script>
-<script src="{% static 'js/jquery-ui.js' %}"></script>
-<script src="{% static 'js/script.js' %}"></script>
-
 <script>
-  // Общая функция для отправки fetch-запроса и показа результата в модалке
-  function sendTracking(form) {
-    const fd = new FormData(form);
+    const navToggle = document.getElementById('navToggle');
+    const navLinks = document.getElementById('navLinks');
+    const dropdowns = document.querySelectorAll('.nav-dropdown');
 
-    fetch(form.action, {
-      method: "POST",
-      headers: {
-        "X-CSRFToken": fd.get("csrfmiddlewaretoken"),
-        "Accept": "application/json"
-      },
-      body: fd
-    })
-    .then(response => {
-      if (!response.ok) throw new Error("Ничего не найдено");
-      const ct = response.headers.get("Content-Type") || "";
-      if (!ct.includes("application/json")) throw new Error("Ожидался JSON, но пришёл " + ct);
-      return response.json();
-    })
-    .then(data => {
-	  if (data.error) throw new Error(data.error);
+    if (navToggle) {
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('open');
+        });
+    }
 
-	  // Перевод статуса
-	  let statusText;
-	  switch (data.status) {
-		case "in_warehouse":
-		  statusText = "{% trans 'На складе' %}";
-		  break;
-		case "location":
-		  statusText = "{% trans 'Местоположение' %}";
-		  break;
-		case "packed":
-		  statusText = "{% trans 'Упакован' %}";
-		  break;
-		case "shipped":
-		  statusText = "{% trans 'Отправлен' %}";
-		  break;
-		case "in_customs":
-		  statusText = "{% trans 'На таможне' %}";
-		  break;
-		case "arrive_warehouse":
-		  statusText = "{% trans 'Прибыл на склад' %}";
-		  break;
-		case "accept_location":
-		  statusText = "{% trans 'Принято в местоположение' %}";
-		  break;
-		case "out_location":
-		  statusText = "{% trans 'Вышел из местоположения' %}";
-		  break;
-		case "delivered":
-		  statusText = "{% trans 'Доставлено' %}";
-		  break;
-		default:
-		  statusText = data.status;
-	  }
-
-	  // Определяем, что выводить: дату прибытия или дату доставки
-	  let dateLabel  = "{% trans 'Дата прибытия' %}";
-	  let dateValue  = data.estimatedArrival;
-	  if (data.status === "delivered") {
-		dateLabel = "{% trans 'Доставлено' %}";
-		dateValue = data.updatedAt
-		  ? data.updatedAt.split(" ")[0]
-		  : data.estimatedArrival;
-	  }
-
-	  // Вставляем в тело модалки
-	  document.getElementById("modalBody").innerHTML = `
-		<div style="line-height:1.6;font-size:16px">
-		  <p><strong>🔎 ID:</strong> ${data.id}</p>
-		  <p><strong>📦 {% trans 'Статус:' %}</strong> ${statusText}</p>
-		  <p><strong>📅 ${dateLabel}:</strong> ${dateValue}</p>
-		</div>`;
-	  document.getElementById("modalFooter").innerHTML = `
-		  <div class="btn-box">
-			<a href="/tracking/${data.id}/" class="theme-btn choose-btn">{% trans 'Подробно' %}</a>
-		  </div>
-		`;
-	  $('#resultModal').modal('show');
-	})
-    .catch(err => {
-      console.error(err);
-      document.getElementById("modalBody").innerHTML = `
-        <div class="alert alert-warning text-center">
-          ${err.message}
-        </div>`;
-      $('#resultModal').modal('show');
+    dropdowns.forEach(dropdown => {
+        const button = dropdown.querySelector('button');
+        button?.addEventListener('click', (event) => {
+            if (window.innerWidth <= 1024) {
+                event.preventDefault();
+                dropdown.classList.toggle('open');
+            }
+        });
     });
-  }
 
-  // Навешиваем обработчик на все формы .track-form
-  document.querySelectorAll('.track-form').forEach(form => {
-    form.addEventListener('submit', e => {
-      e.preventDefault();
-      sendTracking(form);
+    const themeToggle = document.getElementById('themeToggle');
+    const body = document.body;
+    const savedTheme = localStorage.getItem('atlas-theme');
+
+    if (savedTheme) {
+        body.setAttribute('data-theme', savedTheme);
+        updateThemeIcon(savedTheme);
+    }
+
+    themeToggle?.addEventListener('click', () => {
+        const current = body.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        body.setAttribute('data-theme', next);
+        localStorage.setItem('atlas-theme', next);
+        updateThemeIcon(next);
     });
-  });
+
+    function updateThemeIcon(theme) {
+        if (!themeToggle) return;
+        const icon = themeToggle.querySelector('i');
+        if (!icon) return;
+        icon.className = theme === 'dark' ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
+    }
+
+    function sendTracking(form) {
+        const fd = new FormData(form);
+        fetch(form.action, {
+            method: 'POST',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: fd
+        })
+        .then(response => {
+            if (!response.ok) throw new Error('{% trans "Ничего не найдено" %}');
+            const contentType = response.headers.get('Content-Type') || '';
+            if (!contentType.includes('application/json')) {
+                throw new Error('{% trans "Ожидался ответ сервера в формате JSON" %}');
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.error) throw new Error(data.error);
+            let statusText;
+            switch (data.status) {
+                case 'in_warehouse':
+                    statusText = '{% trans "На складе" %}';
+                    break;
+                case 'location':
+                    statusText = '{% trans "Местоположение" %}';
+                    break;
+                case 'packed':
+                    statusText = '{% trans "Упакован" %}';
+                    break;
+                case 'shipped':
+                    statusText = '{% trans "Отправлен" %}';
+                    break;
+                case 'in_customs':
+                    statusText = '{% trans "На таможне" %}';
+                    break;
+                case 'arrive_warehouse':
+                    statusText = '{% trans "Прибыл на склад" %}';
+                    break;
+                case 'accept_location':
+                    statusText = '{% trans "Принято в местоположение" %}';
+                    break;
+                case 'out_location':
+                    statusText = '{% trans "Вышел из местоположения" %}';
+                    break;
+                case 'delivered':
+                    statusText = '{% trans "Доставлено" %}';
+                    break;
+                default:
+                    statusText = data.status;
+            }
+
+            let dateLabel = '{% trans "Дата прибытия" %}';
+            let dateValue = data.estimatedArrival;
+            if (data.status === 'delivered') {
+                dateLabel = '{% trans "Доставлено" %}';
+                dateValue = data.updatedAt ? data.updatedAt.split(' ')[0] : data.estimatedArrival;
+            }
+
+            document.getElementById('modalBody').innerHTML = `
+                <div class="stack">
+                    <div class="info-card">
+                        <strong>ID</strong>
+                        <span class="h5 mb-0">${data.id}</span>
+                    </div>
+                    <div class="info-card">
+                        <strong>{% trans 'Статус' %}</strong>
+                        <span>${statusText}</span>
+                    </div>
+                    <div class="info-card">
+                        <strong>${dateLabel}</strong>
+                        <span>${dateValue}</span>
+                    </div>
+                </div>`;
+            document.getElementById('modalFooter').innerHTML = `
+                <a href="/tracking/${data.id}/" class="btn btn-primary">
+                    <i class="fa-solid fa-arrow-right"></i> {% trans 'Подробнее' %}
+                </a>`;
+            $('#resultModal').modal('show');
+        })
+        .catch(error => {
+            console.error(error);
+            document.getElementById('modalBody').innerHTML = `
+                <div class="alert alert-warning text-center" role="alert">
+                    ${error.message}
+                </div>`;
+            document.getElementById('modalFooter').innerHTML = '';
+            $('#resultModal').modal('show');
+        });
+    }
+
+    document.querySelectorAll('.track-form').forEach(form => {
+        form.addEventListener('submit', event => {
+            event.preventDefault();
+            sendTracking(form);
+        });
+    });
+
+    window.addEventListener('load', function () {
+        setTimeout(function () {
+            const preloader = document.getElementById('preloader');
+            if (!preloader) return;
+            preloader.style.opacity = '0';
+            setTimeout(() => preloader.style.display = 'none', 400);
+        }, 1200);
+    });
 </script>
-
-
-<script>
-  new WOW().init();
-</script>
-<script>
-  window.addEventListener('load', function() {
-    setTimeout(function() {
-      const preloader = document.getElementById('preloader');
-      const logo = preloader.querySelector('.logo');
-
-      // запускаем анимацию исчезновения логотипа
-      logo.classList.add('hide');
-
-      // ждём окончания анимации и скрываем прелоадер
-      setTimeout(() => {
-        preloader.style.transition = 'opacity 0.5s';
-        preloader.style.opacity = 0;
-        setTimeout(() => preloader.style.display = 'none', 500);
-      }, 700);
-    }, 2000); // время показа прелоадера
-  });
-</script>
-<!--<script>-->
-<!--  const themeToggle = document.getElementById('theme-toggle');-->
-<!--  const body = document.body;-->
-
-<!--  // Проверяем, есть ли сохранённая тема-->
-<!--  if (localStorage.getItem('theme') === 'dark') {-->
-<!--    body.classList.add('dark-theme');-->
-<!--  }-->
-
-<!--  themeToggle.addEventListener('click', () => {-->
-<!--    body.classList.toggle('dark-theme');-->
-
-<!--    if (body.classList.contains('dark-theme')) {-->
-<!--      localStorage.setItem('theme', 'dark');-->
-<!--    } else {-->
-<!--      localStorage.setItem('theme', 'light');-->
-<!--    }-->
-<!--  });-->
-<!--</script>-->
+{% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/tarrifs.html
+++ b/templates/tarrifs.html
@@ -1,38 +1,49 @@
 {% extends 'index-2.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
-{% for category in categories %}
-  <div class="sec-title blue centered">
-    <h3><span>{{ category.sender_recipient }}</span></h3>
-    <div class="separater"></div>
-  </div>
-
-  <div class="row clearfix">
-    {% for rate in category.rates_ordered %}
-      <div class="price-block
-                  col-lg-4 col-md-6 col-sm-12
-                  {% if rate.is_hot %}style-two active{% endif %}">
-        <div class="inner-box wow fadeInUp"
-             {% if rate.is_hot %}data-wow-delay="0ms" data-wow-duration="1500ms"{% endif %}>
-          <div class="title">{{ rate.rate_title }}</div>
-          <div class="price-box">
-            <div class="price">{{ rate.price }}$</div>
-            <div class="months">/КГ</div>
-          </div>
-          <ul class="price-list">
-            <li>Минимальный вес: {{ rate.minimal_weight }} кг</li>
-            <li>Срок: {{ rate.delivery_within }} дней</li>
-          </ul>
+<section class="section rates-section" id="rates-full">
+    <div class="container">
+        <div class="section-header">
+            <span class="chip"><i class="fa-solid fa-scale-balanced"></i> {% trans 'Тарифы' %}</span>
+            <h2>{% trans 'Полный каталог тарифов' %}</h2>
+            <p>{% trans 'Найдите оптимальный вариант доставки в нужное направление. Мы обновляем тарифы при любых изменениях на рынке.' %}</p>
         </div>
-      </div>
-    {% empty %}
-      <p>Тарифов для {{ category.sender_recipient }} пока нет.</p>
-    {% endfor %}
-  </div>
-{% empty %}
-  <p>Категорий тарифов пока нет.</p>
-{% endfor %}
-
+        {% for category in categories %}
+            <div class="stack" style="margin-bottom: 48px;">
+                <div>
+                    <h3>{{ category.sender_recipient }}</h3>
+                    {% if category.recipient_country %}
+                        <span class="muted">{{ category.recipient_country }}</span>
+                    {% endif %}
+                </div>
+                {% if category.rates_ordered %}
+                    <div class="rates-grid">
+                        {% for rate in category.rates_ordered %}
+                            <article class="rate-card {% if rate.is_hot %}hot{% endif %}">
+                                {% if rate.is_hot %}
+                                    <span class="badge">🔥 {% trans 'Хит продаж' %}</span>
+                                {% else %}
+                                    <span class="badge">{{ rate.rate_title }}</span>
+                                {% endif %}
+                                <div>
+                                    <div class="price-tag">{{ rate.price }}$ <span>/{% trans 'кг' %}</span></div>
+                                    <div class="rate-meta">
+                                        <span>⚖️ {% trans 'Минимальный вес:' %} {{ rate.minimal_weight }} {% trans 'кг' %}</span>
+                                        <span>⏱ {% trans 'Срок доставки:' %} {{ rate.delivery_within }} {% trans 'дней' %}</span>
+                                    </div>
+                                </div>
+                            </article>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="muted">{% trans 'Для этого направления пока нет активных тарифов.' %}</div>
+                {% endif %}
+            </div>
+        {% empty %}
+            <div class="text-center muted">{% trans 'Категории тарифов временно недоступны.' %}</div>
+        {% endfor %}
+    </div>
+</section>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- rebuild the shared layout with a modern hero, feature, pricing, network, and CTA sections plus a persistent tracking modal
- introduce a new atlas-theme.css design system with light/dark themes, navigation, cards, and utility styles
- refresh contacts, tariffs, and tracking templates to adopt the new styling and component structure

## Testing
- python manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dcc95c6ba8832dab7044655b06e09e