### PR TITLE
Allow uploading large media in broadcast messages

### DIFF
--- a/atlas_express/settings.py
+++ b/atlas_express/settings.py
@@ -151,3 +151,8 @@ STATICFILES_DIRS = [
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+# Allow large uploads for broadcast attachments (up to 100 MB)
+MAX_UPLOAD_SIZE = 100 * 1024 * 1024
+DATA_UPLOAD_MAX_MEMORY_SIZE = MAX_UPLOAD_SIZE
+FILE_UPLOAD_MAX_MEMORY_SIZE = MAX_UPLOAD_SIZE

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -126,7 +126,8 @@ class Rate(models.Model):
 class BroadcastMessage(models.Model):
     title = models.CharField(max_length=255, blank=True, null=True)
     description = models.TextField()
-    image1 = models.ImageField(upload_to='broadcasts/', blank=True, null=True)
-    image2 = models.ImageField(upload_to='broadcasts/', blank=True, null=True)
-    image3 = models.ImageField(upload_to='broadcasts/', blank=True, null=True)
+    image1 = models.FileField(upload_to='broadcasts/', blank=True, null=True)
+    image2 = models.FileField(upload_to='broadcasts/', blank=True, null=True)
+    image3 = models.FileField(upload_to='broadcasts/', blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
+

--- a/templates/send_message.html
+++ b/templates/send_message.html
@@ -17,6 +17,14 @@
                     <h4 class="mb-0">Создать рассылку</h4>
                 </div>
                 <div class="card-body p-4">
+                    {% if messages %}
+                        {% for message in messages %}
+                            <div class="alert alert-{{ message.tags|default:'info' }} alert-dismissible fade show" role="alert">
+                                {{ message }}
+                                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                            </div>
+                        {% endfor %}
+                    {% endif %}
                     <form method="post" enctype="multipart/form-data">
                         {% csrf_token %}
 
@@ -26,22 +34,22 @@
                             <textarea class="form-control rounded-3" id="description" name="description" rows="4" required placeholder="Введите текст рассылки..."></textarea>
                         </div>
 
-                        <!-- Фото -->
+                        <!-- Медиа-файлы -->
                         <div class="row g-3">
                             <div class="col-md-4">
-                                <label for="image1" class="form-label fw-semibold">Фото 1</label>
-                                <input type="file" class="form-control rounded-3" id="image1" name="image1" accept="image/*" onchange="previewImage(this, 'preview1')">
-                                <img id="preview1" class="img-fluid mt-2 d-none rounded-3 shadow-sm"/>
+                                <label for="image1" class="form-label fw-semibold">Файл 1 (фото/видео)</label>
+                                <input type="file" class="form-control rounded-3" id="image1" name="image1" accept="image/*,video/*" onchange="previewMedia(this, 'preview1')">
+                                <div id="preview1" class="mt-2 d-none"></div>
                             </div>
                             <div class="col-md-4">
-                                <label for="image2" class="form-label fw-semibold">Фото 2</label>
-                                <input type="file" class="form-control rounded-3" id="image2" name="image2" accept="image/*" onchange="previewImage(this, 'preview2')">
-                                <img id="preview2" class="img-fluid mt-2 d-none rounded-3 shadow-sm"/>
+                                <label for="image2" class="form-label fw-semibold">Файл 2 (фото/видео)</label>
+                                <input type="file" class="form-control rounded-3" id="image2" name="image2" accept="image/*,video/*" onchange="previewMedia(this, 'preview2')">
+                                <div id="preview2" class="mt-2 d-none"></div>
                             </div>
                             <div class="col-md-4">
-                                <label for="image3" class="form-label fw-semibold">Фото 3</label>
-                                <input type="file" class="form-control rounded-3" id="image3" name="image3" accept="image/*" onchange="previewImage(this, 'preview3')">
-                                <img id="preview3" class="img-fluid mt-2 d-none rounded-3 shadow-sm"/>
+                                <label for="image3" class="form-label fw-semibold">Файл 3 (фото/видео)</label>
+                                <input type="file" class="form-control rounded-3" id="image3" name="image3" accept="image/*,video/*" onchange="previewMedia(this, 'preview3')">
+                                <div id="preview3" class="mt-2 d-none"></div>
                             </div>
                         </div>
 
@@ -56,7 +64,7 @@
             </div>
 
             <!-- История рассылок -->
-            {% if messages %}
+            {% if recent_messages %}
             <div class="card shadow-sm border-0 rounded-4 mt-5">
                 <div class="card-header bg-light d-flex justify-content-between align-items-center rounded-top-4">
                     <h5 class="mb-0">Последние рассылки</h5>
@@ -67,7 +75,7 @@
                 </div>
                 <div class="card-body">
                     <ul class="list-group list-group-flush">
-                        {% for msg in messages %}
+                        {% for msg in recent_messages %}
                         <li class="list-group-item">
                             <p class="mb-1"><strong>{{ msg.description|truncatewords:15 }}</strong></p>
                             <small class="text-muted">{{ msg.created_at|date:"d.m.Y H:i" }}</small>
@@ -86,17 +94,39 @@
 <!-- Bootstrap JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
-<!-- JS для предпросмотра фото -->
+<!-- JS для предпросмотра медиа -->
 <script>
-function previewImage(input, previewId) {
-    const preview = document.getElementById(previewId);
+function previewMedia(input, containerId) {
+    const container = document.getElementById(containerId);
+    container.innerHTML = '';
+    container.classList.add("d-none");
+
     if (input.files && input.files[0]) {
-        const reader = new FileReader();
-        reader.onload = e => {
-            preview.src = e.target.result;
-            preview.classList.remove("d-none");
-        };
-        reader.readAsDataURL(input.files[0]);
+        const file = input.files[0];
+        const url = URL.createObjectURL(file);
+        let element;
+
+        if (file.type.startsWith('image/')) {
+            element = document.createElement('img');
+            element.className = 'img-fluid rounded-3 shadow-sm';
+            element.onload = () => URL.revokeObjectURL(url);
+        } else if (file.type.startsWith('video/')) {
+            element = document.createElement('video');
+            element.className = 'w-100 rounded-3 shadow-sm';
+            element.controls = true;
+            element.onloadeddata = () => URL.revokeObjectURL(url);
+        } else {
+            const info = document.createElement('p');
+            info.className = 'text-muted small';
+            info.textContent = 'Предпросмотр недоступен для этого типа файла';
+            container.appendChild(info);
+            container.classList.remove('d-none');
+            return;
+        }
+
+        element.src = url;
+        container.appendChild(element);
+        container.classList.remove('d-none');
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- allow broadcast attachments to include generic media files instead of images only
- raise the server-side upload limit to 100 MB and surface validation feedback in the UI
- update the send message page to preview both images and videos and show status alerts

## Testing
- `python manage.py makemigrations` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4b92cdba0832dab5a1c0499dd1a72